### PR TITLE
remove onMounted fetchMe on App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { onMounted, watch } from 'vue'
+import { watch } from 'vue'
 
 import { useFetchMeUsecase } from '/@/features/user/usecase'
 
@@ -8,10 +8,6 @@ import './styles/main.css'
 import './styles/scrollbar.css'
 import './styles/toast.css'
 import { useRoute } from 'vue-router'
-
-onMounted(async () => {
-  await useFetchMeUsecase()
-})
 
 const route = useRoute()
 


### PR DESCRIPTION
### **User description**
fix https://q.trap.jp/messages/01919ce8-9e20-7454-8245-11998a107511
fetchが早すぎて変なデータを取ってきていたので適当に消してみたら動いたのでこれでよさそうです(meのデータ自体はちょっと下のwatch内で取れてる)


___

### **PR Type**
bug_fix


___

### **Description**
- `onMounted` lifecycle hook was removed from `App.vue` to prevent premature data fetching.
- The call to `useFetchMeUsecase` was eliminated from `onMounted`, as it was fetching incorrect data.
- The import statement for `onMounted` was removed, simplifying the code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Remove `onMounted` lifecycle hook and fetch call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.vue

<li>Removed <code>onMounted</code> lifecycle hook.<br> <li> Eliminated the call to <code>useFetchMeUsecase</code> within <code>onMounted</code>.<br> <li> Simplified imports by removing <code>onMounted</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/272/files#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

