### PR TITLE
feat/GitHub Actions を月イチで dependabot に掛ける

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,3 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    groups:
-      actions-deps:
-        patterns:
-          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,12 @@ updates:
       - "dependencies"
     reviewers:
       - reiroop
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 20
+    groups:
+      actions-deps:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: monthly
     open-pull-requests-limit: 20
@@ -17,16 +17,15 @@ updates:
         update-types:
           - 'patch'
     versioning-strategy: increase
-    target-branch: "main"
+    target-branch: 'main'
     labels:
-      - "dependencies"
+      - 'dependencies'
     reviewers:
       - reiroop
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 20
     groups:
       actions-deps:
         patterns:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,17 +8,17 @@ categories:
     labels:
       - 'bug'
   - title: '🧰 Maintenance'
-    labels: 
+    labels:
       - 'chore'
       - 'dependencies'
   - title: '📖 Documentation'
-    labels: 
+    labels:
       - 'docs'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's New
   $CHANGES
-  
+
   ## Contributors
   $CONTRIBUTORS
 autolabeler:


### PR DESCRIPTION
fix: #205 

それぞれコメントのような意味です 🙇 
```yaml
  - package-ecosystem: github-actions
    directory: '/' # .github/workflows を見る ref: https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory
    schedule: # 月イチ
      interval: monthly
    groups: # 全部まとめて PR を出す
      actions-deps:
        patterns:
          - '*'
```