### PR TITLE
♿️ ヘッダーに関する a11y の向上

### DIFF
--- a/src/components/modal/ModalWrapper.vue
+++ b/src/components/modal/ModalWrapper.vue
@@ -13,7 +13,7 @@ const handleKeydown = (e: KeyboardEvent) => {
     <div
       role="button"
       tabindex="0"
-      aria-label="Close modal"
+      aria-label="モーダルを閉じる"
       className="z-10 fixed top-0 left-0 h-full w-full bg-surface-secondary/50"
       @click.self="emit('closeModal')"
       @keydown="handleKeydown">

--- a/src/components/modal/ModalWrapper.vue
+++ b/src/components/modal/ModalWrapper.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
 const emit = defineEmits<(e: 'closeModal') => void>()
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    emit('closeModal')
+  }
+}
 </script>
 
 <template>
   <teleport to="body">
     <div
+      role="button"
+      tabindex="0"
+      aria-label="Close modal"
       className="z-10 fixed top-0 left-0 h-full w-full bg-surface-secondary/50"
-      @click.self="emit('closeModal')">
+      @click.self="emit('closeModal')"
+      @keydown="handleKeydown">
       <slot />
     </div>
   </teleport>

--- a/src/components/navigation/HeaderButton.vue
+++ b/src/components/navigation/HeaderButton.vue
@@ -9,7 +9,7 @@ const props = defineProps<Props>()
 </script>
 
 <template>
-  <router-link 
+  <router-link
     :class="props.isHere ? 'cursor-default' : ''"
     :to="props.path"
     :aria-current="props.isHere ? 'page' : undefined"

--- a/src/components/navigation/HeaderButton.vue
+++ b/src/components/navigation/HeaderButton.vue
@@ -9,7 +9,11 @@ const props = defineProps<Props>()
 </script>
 
 <template>
-  <router-link :class="props.isHere ? 'cursor-default' : ''" :to="props.path">
+  <router-link 
+    :class="props.isHere ? 'cursor-default' : ''"
+    :to="props.path"
+    :aria-current="props.isHere ? 'page' : undefined"
+    tabindex="0">
     <div
       class="rounded-3xl p-2"
       :class="props.isHere ? 'bg-hover-primary' : 'hover:bg-hover-primary'">

--- a/src/components/navigation/JomonHeader.vue
+++ b/src/components/navigation/JomonHeader.vue
@@ -32,10 +32,15 @@ const handleOpenDrawer = () => {
   <header
     class="fixed flex h-12 w-full items-center bg-white pl-2 shadow-sm"
     :class="shouldShowModal ? 'z-30' : 'z-10'">
-    <button class="flex items-center md:hidden" @click="handleOpenDrawer">
-      <Bars3Icon class="h-8 w-8" />
+    <button 
+      class="flex items-center md:hidden" 
+      @click="handleOpenDrawer"
+      aria-label="メニューを開く"
+      :aria-expanded="shouldShowModal"
+      aria-controls="side-drawer">
+      <Bars3Icon class="h-8 w-8" aria-hidden="true" />
     </button>
-    <RouterLink to="/">
+    <RouterLink to="/" aria-label="ホーム" tabindex="0">
       <JomonLogo />
     </RouterLink>
     <div class="flex h-full flex-1 justify-between px-2">
@@ -44,7 +49,8 @@ const handleOpenDrawer = () => {
         <a
           href="https://wiki.trap.jp/services/Jomon"
           rel="noreferrer noopener"
-          target="_blank">
+          target="_blank"
+          tabindex="0">
           ヘルプ
         </a>
         <UserIcon v-if="me !== undefined" :name="me.name" />
@@ -54,6 +60,6 @@ const handleOpenDrawer = () => {
   <!--遷移時にドロワーを閉じるようにするためにドロワーコンポーネント内でwrapperを使うことになりそう？-->
   <!--onBeforeRouteUpdateはヘッダーコンポーネントがルーター内に入っていないので使えない-->
   <ModalWrapper v-if="shouldShowModal" @close-modal="closeModal">
-    <SideDrawer />
+    <SideDrawer id="side-drawer" />
   </ModalWrapper>
 </template>

--- a/src/components/navigation/JomonHeader.vue
+++ b/src/components/navigation/JomonHeader.vue
@@ -34,10 +34,10 @@ const handleOpenDrawer = () => {
     :class="shouldShowModal ? 'z-30' : 'z-10'">
     <button
       class="flex items-center md:hidden"
-      @click="handleOpenDrawer"
       aria-label="メニューを開く"
       :aria-expanded="shouldShowModal"
-      aria-controls="side-drawer">
+      aria-controls="side-drawer"
+      @click="handleOpenDrawer">
       <Bars3Icon class="h-8 w-8" aria-hidden="true" />
     </button>
     <RouterLink to="/" aria-label="ホーム" tabindex="0">

--- a/src/components/navigation/JomonHeader.vue
+++ b/src/components/navigation/JomonHeader.vue
@@ -32,8 +32,8 @@ const handleOpenDrawer = () => {
   <header
     class="fixed flex h-12 w-full items-center bg-white pl-2 shadow-sm"
     :class="shouldShowModal ? 'z-30' : 'z-10'">
-    <button 
-      class="flex items-center md:hidden" 
+    <button
+      class="flex items-center md:hidden"
       @click="handleOpenDrawer"
       aria-label="メニューを開く"
       :aria-expanded="shouldShowModal"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- モーダル閉じるUIにARIAとキー操作対応

- HeaderButtonにaria-currentとフォーカス追加

- JomonHeaderにARIA属性とtabindex付与

- SideDrawerにid属性追加


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ModalWrapper.vue</strong><dd><code>モーダル閉じるUIにキーボード/ARIA対応</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/modal/ModalWrapper.vue

<li>背景divに<code>role="button"</code>と<code>tabindex="0"</code>追加<br> <li> <code>aria-label="Close modal"</code>を指定<br> <li> Enter/Spaceキーでモーダルを閉じる


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/425/files#diff-28d657942ff7805ea9efba93cb9fda15de54dae22721dcf6c5d96e13082f4579">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HeaderButton.vue</strong><dd><code>ヘッダーボタンにフォーカスとaria-current追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/navigation/HeaderButton.vue

- `aria-current`で現在ページを示す
- `tabindex="0"`でフォーカス可能に


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/425/files#diff-92350479e02a5f0dec6a702c5b6f856a7252ffae006da5b9fe59a5d089022d1a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JomonHeader.vue</strong><dd><code>JomonHeaderにARIA属性とtabindex追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/navigation/JomonHeader.vue

<li>メニューボタンに<code>aria-label</code>,<code>aria-expanded</code>,<code>aria-controls</code><br> <li> アイコンに<code>aria-hidden="true"</code>指定<br> <li> <code>RouterLink</code>に<code>aria-label</code>と<code>tabindex</code><br> <li> ヘルプリンクに<code>tabindex="0"</code>追加<br> <li> <code>SideDrawer</code>に<code>id="side-drawer"</code>設定


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/425/files#diff-b22831181efe0e234b4be1ec818ff86837837b028ecc7ca9bec257dcb415e552">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>