### PR TITLE
feat: UserIcon.vueにsize引数を追加

### DIFF
--- a/src/components/shared/UserIcon.vue
+++ b/src/components/shared/UserIcon.vue
@@ -1,14 +1,17 @@
 <script lang="ts" setup>
-// TODO: sizeも受け取りたい
-defineProps<{
-  name: string
-}>()
+withDefaults(
+  defineProps<{
+    size?: number
+    name: string
+  }>(),
+  { size: 12 }
+)
 </script>
 
 <template>
   <img
     :alt="name"
-    class="rounded-full h-full p-1"
+    :class="`rounded-full h-full p-1 w-${size}`"
     :src="`https://q.trap.jp/api/v3/public/icon/${name}`"
     :title="name" />
 </template>


### PR DESCRIPTION
### **User description**
fix: #470


___

### **PR Type**
Enhancement


___

### **Description**
- sizeプロップを追加

- デフォルト値を12に設定

- 幅クラスを動的にバインド


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserIcon.vue</strong><dd><code>sizeプロップと幅クラス追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/shared/UserIcon.vue

- withDefaultsで`size`プロップ定義、デフォルト12
- テンプレートで`w-${size}`クラス使用


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/487/files#diff-8149364513d1859cd03fa607d7105c3b2509007c7b6f3c8fe439c15dac0a376e">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>