### PR TITLE
パーティション名の未入力時に警告を表示#471

### DIFF
--- a/src/pages/NewPartitionPage.vue
+++ b/src/pages/NewPartitionPage.vue
@@ -1,37 +1,14 @@
 <script lang="ts" setup>
-import { useRouter } from 'vue-router'
-import { useToast } from 'vue-toastification'
 import BaseInput from '/@/components/shared/BaseInput.vue'
 import SimpleButton from '/@/components/shared/SimpleButton.vue'
-import { createPartitionUsecase } from '/@/features/partition/usecase'
+
 import { useFetchUsersUsecase } from '/@/features/user/usecase'
 import { useUserStore } from '/@/stores/user'
 import { useNewPartition } from './composables/useNewPartition'
 
-const toast = useToast()
-const router = useRouter()
-
 const { isUserFetched } = useUserStore()
 
-const { isSending, partition } = useNewPartition()
-
-const handleCreatePartition = async () => {
-  if (
-    partition.value.name === ''
-  ) {
-    toast.warning('パーティション名は必須です')
-    return
-  }
-  try {
-    await createPartitionUsecase(partition.value)
-    toast.success('パーティションを作成しました')
-    router.push('/partitions')
-  } catch (e) {
-    if (e instanceof Error) {
-      toast.error(e.message)
-    }
-  }
-}
+const { isSending, partition, handleCreatePartition } = useNewPartition()
 
 if (!isUserFetched.value) {
   await useFetchUsersUsecase()

--- a/src/pages/composables/useNewPartition.ts
+++ b/src/pages/composables/useNewPartition.ts
@@ -1,10 +1,14 @@
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from 'vue-toastification'
 
 import type { PartitionSeed } from '/@/features/partition/model'
+import { createPartitionUsecase } from '/@/features/partition/usecase'
 
 export const useNewPartition = () => {
   const isSending = ref(false)
-
+  const toast = useToast()
+  const router = useRouter()
   const partition = ref<PartitionSeed>({
     name: '',
     budget: 0,
@@ -13,6 +17,21 @@ export const useNewPartition = () => {
       state: 'available'
     }
   })
+  const handleCreatePartition = async () => {
+    if (partition.value.name === '') {
+      toast.warning('パーティション名は必須です')
+      return
+    }
+    try {
+      await createPartitionUsecase(partition.value)
+      toast.success('パーティションを作成しました')
+      router.push('/partitions')
+    } catch (e) {
+      if (e instanceof Error) {
+        toast.error(e.message)
+      }
+    }
+  }
 
-  return { isSending, partition }
+  return { isSending, partition, handleCreatePartition }
 }


### PR DESCRIPTION
### **User description**
パーティションの新規作成において、パーティション名が入力されていなかった場合に、警告を表示する。


___

### **PR Type**
Bug fix


___

### **Description**
未入力パーティション名で作成を抑止
必須チェックと警告トーストを追加
作成前の早期リターンを実装
UX向上のためのバリデーション


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["新規パーティションページ"]
  Validate["名前未入力チェック"]
  Warn["警告トースト表示"]
  Abort["作成処理中断"]
  Create["作成ユースケース実行"]

  UI -- "作成ボタンクリック" --> Validate
  Validate -- "未入力" --> Warn
  Warn -- "表示後" --> Abort
  Validate -- "入力済み" --> Create
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NewPartitionPage.vue</strong><dd><code>名前未入力時の警告と早期中断追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/NewPartitionPage.vue

<ul><li>作成前に<code>partition.value.name</code>の空文字判定を追加<br> <li> 警告トースト<code>toast.warning</code>で必須メッセージを表示<br> <li> 未入力時は<code>return</code>で処理を中断</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/510/files#diff-045c695f58143f6ed336b05d290e4f9289113669c0cdd209a362d1a0e67b4471">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

