### PR TITLE
会計管理者を選択しても、ボタンが変形しないようにした

### DIFF
--- a/src/pages/AccountManagerPage.vue
+++ b/src/pages/AccountManagerPage.vue
@@ -79,6 +79,7 @@ if (me.value?.accountManager) {
           :disabled="isSending"
           font-size="lg"
           padding="sm"
+          class="max-h-14"
           @click.stop="
             () => {
               addAccountManagers(addList)
@@ -99,6 +100,7 @@ if (me.value?.accountManager) {
           :disabled="isSending"
           font-size="lg"
           padding="sm"
+          class="max-h-14"
           @click.stop="
             () => {
               removeAccountManagers(removeList)
@@ -122,6 +124,7 @@ if (me.value?.accountManager) {
           :disabled="deleteTagList.length === 0 || isSending"
           font-size="lg"
           padding="sm"
+          class="max-h-14"
           @click.stop="handleDeleteTags">
           選択したタグを削除
         </SimpleButton>


### PR DESCRIPTION
#538 会計管理者決定ボタンの高さの最大値を決め、選択後も変形しないようにした。
モバイルサイズでは、ボタンの高さが低くなるため影響はない。