### PR TITLE
feat: src/features/partitionGroup の実装

### DIFF
--- a/src/features/partitionGroup/__mocks__/handlers.ts
+++ b/src/features/partitionGroup/__mocks__/handlers.ts
@@ -1,0 +1,53 @@
+import type { PartitionGroupSeed } from '../entities'
+import type { PartitionGroup } from '@/lib/apis'
+import { http, HttpResponse } from 'msw'
+
+export const mockPartitionGroup: PartitionGroup = {
+  id: 'group-1',
+  name: 'テストパーティショングループ',
+  parent_partition_group: null,
+  depth: 1,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z'
+}
+
+const mockPartitionGroups = Array(10).fill(mockPartitionGroup)
+
+export const partitionGroupHandlers = [
+  http.get('/api/partition-groups', () => {
+    return HttpResponse.json(mockPartitionGroups)
+  }),
+
+  http.get('/api/partition-groups/:id', ({ params }) => {
+    if (params.id === 'group-1') {
+      return HttpResponse.json(mockPartitionGroup)
+    }
+    return new HttpResponse(null, { status: 404 })
+  }),
+
+  http.post('/api/partition-groups', async ({ request }) => {
+    const seed = (await request.json()) as PartitionGroupSeed
+    const partitionGroup: PartitionGroup = {
+      ...mockPartitionGroup,
+      name: seed.name,
+      parent_partition_group: seed.parentPartitionGroupId,
+      depth: seed.depth
+    }
+    return HttpResponse.json(partitionGroup)
+  }),
+
+  http.put('/api/partition-groups/:id', async ({ request }) => {
+    const seed = (await request.json()) as PartitionGroupSeed
+    const partitionGroup: PartitionGroup = {
+      ...mockPartitionGroup,
+      name: seed.name,
+      parent_partition_group: seed.parentPartitionGroupId,
+      depth: seed.depth
+    }
+    return HttpResponse.json(partitionGroup)
+  }),
+
+  http.delete('/api/partition-groups/:id', () => {
+    return new HttpResponse(null, { status: 204 })
+  })
+]

--- a/src/features/partitionGroup/data/converter.ts
+++ b/src/features/partitionGroup/data/converter.ts
@@ -1,0 +1,13 @@
+import type { PartitionGroup } from '../entities'
+import type { PartitionGroup as ApiPartitionGroup } from '@/lib/apis'
+
+export const convertPartitionGroupFromData = (
+  partitionGroup: ApiPartitionGroup
+): PartitionGroup => ({
+  id: partitionGroup.id,
+  name: partitionGroup.name,
+  parentPartitionGroupId: partitionGroup.parent_partition_group,
+  depth: partitionGroup.depth,
+  createdAt: partitionGroup.created_at,
+  updatedAt: partitionGroup.updated_at
+})

--- a/src/features/partitionGroup/data/repository.ts
+++ b/src/features/partitionGroup/data/repository.ts
@@ -1,0 +1,49 @@
+import type { PartitionGroup, PartitionGroupSeed } from '../entities'
+import { convertPartitionGroupFromData } from './converter'
+import apis, { type PartitionGroupInput } from '@/lib/apis'
+
+export const usePartitionGroupRepository = () => {
+  return createPartitionGroupRepository()
+}
+
+const toPartitionGroupInput = (
+  partitionGroup: PartitionGroupSeed
+): PartitionGroupInput => ({
+  name: partitionGroup.name,
+  parent_partition_group: partitionGroup.parentPartitionGroupId,
+  depth: partitionGroup.depth
+})
+
+const createPartitionGroupRepository = () => ({
+  fetchPartitionGroups: async (): Promise<PartitionGroup[]> => {
+    const { data } = await apis.getPartitionGroups()
+
+    return data.map(convertPartitionGroupFromData)
+  },
+  fetchPartitionGroup: async (id: string): Promise<PartitionGroup> => {
+    const { data } = await apis.getPartitionGroup(id)
+
+    return convertPartitionGroupFromData(data)
+  },
+  createPartitionGroup: async (
+    partitionGroup: PartitionGroupSeed
+  ): Promise<PartitionGroup> => {
+    const { data } = await apis.postPartitionGroup(
+      toPartitionGroupInput(partitionGroup)
+    )
+    return convertPartitionGroupFromData(data)
+  },
+  editPartitionGroup: async (
+    id: string,
+    partitionGroup: PartitionGroupSeed
+  ): Promise<PartitionGroup> => {
+    const { data } = await apis.putPartitionGroup(
+      id,
+      toPartitionGroupInput(partitionGroup)
+    )
+    return convertPartitionGroupFromData(data)
+  },
+  deletePartitionGroup: async (id: string) => {
+    await apis.deletePartitionGroup(id)
+  }
+})

--- a/src/features/partitionGroup/entities.ts
+++ b/src/features/partitionGroup/entities.ts
@@ -1,0 +1,14 @@
+export interface PartitionGroup {
+  id: string
+  name: string
+  parentPartitionGroupId: string | null
+  depth: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PartitionGroupSeed {
+  name: string
+  parentPartitionGroupId: string | null
+  depth: number
+}

--- a/src/features/partitionGroup/store.ts
+++ b/src/features/partitionGroup/store.ts
@@ -1,0 +1,124 @@
+import { usePartitionGroupRepository } from './data/repository'
+import type { PartitionGroup, PartitionGroupSeed } from './entities'
+import type { User } from '@/features/user/entities'
+import { defineStore, storeToRefs } from 'pinia'
+
+const createDefaultPartitionGroupSeed = (): PartitionGroupSeed => ({
+  name: '',
+  parentPartitionGroupId: null,
+  depth: 0
+})
+
+const createPartitionGroupStore = defineStore('partitionGroup', {
+  state: () => ({
+    partitionGroups: [] as PartitionGroup[],
+    isPartitionGroupFetched: false,
+    currentPartitionGroup: undefined as PartitionGroup | undefined,
+    editedValue: createDefaultPartitionGroupSeed()
+  }),
+  getters: {
+    partitionGroupOptions: state =>
+      state.partitionGroups.map(group => ({
+        key: group.name,
+        value: group.id
+      })),
+    canEditPartitionGroup: () => (user: User | undefined) => {
+      if (!user) return false
+      return user.accountManager
+    }
+  },
+  actions: {
+    async fetchPartitionGroups() {
+      const repository = usePartitionGroupRepository()
+      try {
+        this.partitionGroups = await repository.fetchPartitionGroups()
+        this.isPartitionGroupFetched = true
+      } catch (e) {
+        throw new Error(
+          'パーティショングループ一覧の取得に失敗しました: ' +
+            (e instanceof Error ? e.message : String(e))
+        )
+      }
+    },
+    async fetchPartitionGroup(id: string) {
+      const repository = usePartitionGroupRepository()
+      try {
+        const partitionGroup = await repository.fetchPartitionGroup(id)
+        this.currentPartitionGroup = partitionGroup
+        this.editedValue = {
+          name: partitionGroup.name,
+          parentPartitionGroupId: partitionGroup.parentPartitionGroupId,
+          depth: partitionGroup.depth
+        }
+      } catch {
+        throw new Error('パーティショングループの取得に失敗しました')
+      }
+    },
+    async createPartitionGroup(partitionGroup: PartitionGroupSeed) {
+      const repository = usePartitionGroupRepository()
+      try {
+        const res = await repository.createPartitionGroup(partitionGroup)
+        this.partitionGroups.unshift(res)
+      } catch {
+        throw new Error('パーティショングループの作成に失敗しました')
+      }
+    },
+    async editPartitionGroup(
+      id: string,
+      partitionGroupSeed: PartitionGroupSeed
+    ) {
+      if (!this.currentPartitionGroup) return
+      const repository = usePartitionGroupRepository()
+      try {
+        const res = await repository.editPartitionGroup(id, partitionGroupSeed)
+        this.currentPartitionGroup = res
+        const index = this.partitionGroups.findIndex(
+          partitionGroup => partitionGroup.id === res.id
+        )
+        if (index !== -1) {
+          this.partitionGroups.splice(index, 1, res)
+        }
+      } catch {
+        this.editedValue = {
+          name: this.currentPartitionGroup.name,
+          parentPartitionGroupId:
+            this.currentPartitionGroup.parentPartitionGroupId,
+          depth: this.currentPartitionGroup.depth
+        }
+        throw new Error('パーティショングループの更新に失敗しました')
+      }
+    },
+    async deletePartitionGroup(id: string) {
+      const repository = usePartitionGroupRepository()
+      try {
+        await repository.deletePartitionGroup(id)
+        this.partitionGroups = this.partitionGroups.filter(
+          partitionGroup => partitionGroup.id !== id
+        )
+      } catch {
+        throw new Error('パーティショングループの削除に失敗しました')
+      }
+    },
+    resetDetail() {
+      this.currentPartitionGroup = undefined
+      this.editedValue = createDefaultPartitionGroupSeed()
+    }
+  }
+})
+
+export const usePartitionGroupStore = () => {
+  const store = createPartitionGroupStore()
+  const refs = storeToRefs(store)
+
+  return {
+    ...refs,
+    fetchPartitionGroups: store.fetchPartitionGroups.bind(store),
+    fetchPartitionGroup: store.fetchPartitionGroup.bind(store),
+    createPartitionGroup: store.createPartitionGroup.bind(store),
+    editPartitionGroup: store.editPartitionGroup.bind(store),
+    deletePartitionGroup: store.deletePartitionGroup.bind(store),
+    resetDetail: store.resetDetail.bind(store)
+  }
+}
+
+export type PartitionGroupStore = ReturnType<typeof usePartitionGroupStore>


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- パーティショングループ機能の実装

- APIデータ変換ロジックを追加

- リポジトリ層でCRUD実装

- MSWハンドラでAPIモック追加


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Entities["entities: 型定義追加"]
  Converter["data/converter: API->Domain変換"]
  Repository["data/repository: CRUDリポジトリ"]
  Store["store: Piniaストア実装"]
  MSW["__mocks__/handlers: MSWモックAPI"]

  Entities -- 参照 --> Converter
  Converter -- 利用 --> Repository
  Repository -- 利用 --> Store
  MSW -- エンドポイント提供 --> Repository
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.ts</strong><dd><code>MSWでパーティショングループAPIをモック</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partitionGroup/__mocks__/handlers.ts

- パーティショングループAPIのMSWモック追加
- 一覧・詳細・作成・更新・削除を実装
- 入出力スキーマに合わせたJSON構築


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/574/files#diff-4ea9e31f84811ccc52c8b208d783a559cd5e010653c97c797a18cc4de82540ad">+53/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>converter.ts</strong><dd><code>APIデータからドメインモデルへ変換</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partitionGroup/data/converter.ts

- API型からドメイン型へ変換関数追加
- スネークケースをキャメルケースへ変換


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/574/files#diff-6e34a357a91468149b8d61ed2deaa8d6e3fe05c0f2fc1448d2dfcd34f4df7612">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>repository.ts</strong><dd><code>パーティショングループCRUDリポジトリ追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partitionGroup/data/repository.ts

- CRUDリポジトリ関数を実装
- 入力変換とAPI呼び出しをラップ
- 取得結果をドメインへ変換


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/574/files#diff-ee5f2a607a592e6032e2bfd8021588d84883ab5432bcd480c26554d7b891fb9c">+49/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entities.ts</strong><dd><code>パーティショングループの型定義を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partitionGroup/entities.ts

- ドメインモデル型を定義
- 作成・更新用Seed型を定義


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/574/files#diff-ac552228ce6ef75d1fc4115c12f390fcb8347afb3a7d1ba3bdb5c4a71bc18e23">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>パーティショングループ用Piniaストア実装</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partitionGroup/store.ts

- Piniaストアで状態管理を実装
- CRUDアクションとエラーハンドリング追加
- オプションGetterや編集値の管理


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/574/files#diff-d605336e956eecead2befe3686d09d9c56117a75057743cf70acd7b8e9a1b2fc">+124/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

