### PR TITLE
Adjust Dependabot cooldown thresholds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,13 @@ updates:
     cooldown:
       - days: 30
         update-types:
-          - 'semver-major'
+          - 'version-update:semver-major'
       - days: 7
         update-types:
-          - 'semver-minor'
+          - 'version-update:semver-minor'
       - days: 7
         update-types:
-          - 'semver-patch'
+          - 'version-update:semver-patch'
     open-pull-requests-limit: 20
     groups:
       types:
@@ -37,11 +37,11 @@ updates:
     cooldown:
       - days: 30
         update-types:
-          - 'semver-major'
+          - 'version-update:semver-major'
       - days: 7
         update-types:
-          - 'semver-minor'
+          - 'version-update:semver-minor'
       - days: 7
         update-types:
-          - 'semver-patch'
+          - 'version-update:semver-patch'
     open-pull-requests-limit: 10


### PR DESCRIPTION
### **User description**
## Summary
- replace the single seven-day cooldown with semver-specific cooldown values for npm updates
- apply the same cooldown configuration to GitHub Actions updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e9a9dae15083238eae324e9dab608b


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Dependabotにクールダウンを導入

- npm更新にセマンティック別期間を設定

- GitHub Actions更新にも同設定を適用

- PR同時上限は現状維持


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependabot.yml"] -- "npm: semver別クールダウン追加" --> B["semver-major:30日 / minor:7日 / patch:7日"]
  A -- "GitHub Actions: 同設定適用" --> C["semver-major:30日 / minor:7日 / patch:7日"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Dependabotにセマンティック別クールダウンを設定</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>npm更新にcooldownを追加<br> <li> major:30日、minor/patch:7日を設定<br> <li> GitHub Actions更新にも同cooldownを追加<br> <li> 既存のスケジュール/上限等は維持</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/581/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

