### PR TITLE
chore: add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 20
     groups:
       types:
@@ -24,4 +26,6 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- dependabot の npm / GitHub Actions 更新に 7 日のクールダウンを追加

## Testing
- not needed