### PR TITLE
Enable automated merging for Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,4 +30,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Summary
- enable auto-merge queuing as soon as Dependabot opens or updates a PR
- keep metadata check to avoid auto-merging major version bumps
- rely on branch protection for review/CI requirements per GitHub guidance
- switch auto-merge mode from squash to merge as requested

## Testing
- [x] not run