### PR TITLE
fix: `type` が `number` のとき、空の入力を null にする

### DIFF
--- a/src/components/shared/BaseInput.vue
+++ b/src/components/shared/BaseInput.vue
@@ -38,7 +38,12 @@ const handleBlur = () => {
 
 const handleChange = (e: Event) => {
   const target = e.target as HTMLInputElement
-  model.value = props.type === 'number' ? Number(target.value) : target.value
+  model.value =
+    props.type === 'number'
+      ? target.value === ''
+        ? null
+        : Number(target.value)
+      : target.value
 }
 
 const handleKey = (e: KeyboardEvent) => {


### PR DESCRIPTION
### **User description**
close: #589 

### 挫折したこと
初期値が 0 になってしまうのを直したかったのですが、無理でした。ページ開いたときに空欄であってほしい...！


___

### **PR Type**
Bug fix


___

### **Description**
- 数値入力の空欄を0にしない

- 空文字はnullとして保持

- バリデーション連携を容易化


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Input["数値入力値（target.value）"]
  TypeCheck["type === 'number' 判定"]
  IsEmpty["値が空文字か？"]
  SetNull["model.value = null"]
  SetNumber["model.value = Number(value)"]
  SetString["model.value = value"]

  Input -- "change" --> TypeCheck
  TypeCheck -- "number" --> IsEmpty
  TypeCheck -- "その他" --> SetString
  IsEmpty -- "はい" --> SetNull
  IsEmpty -- "いいえ" --> SetNumber
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseInput.vue</strong><dd><code>空入力時はnullにする数値入力処理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/shared/BaseInput.vue

- 数値タイプ時の代入ロジックを条件分岐
- 空文字はnull、それ以外はNumberに変換
- 文字列タイプは従来通りの代入を維持


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/600/files#diff-e5505f77dffb87d3bce34ce3adf938d6e7136bfad998047d88f04c9c13bbeae1">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

