### PR TITLE
fix: パーティション編集時にnull予算を保持

### DIFF
--- a/src/features/partition/store.ts
+++ b/src/features/partition/store.ts
@@ -51,7 +51,7 @@ const createPartitionStore = defineStore('partition', {
         this.currentPartition = partition
         this.editedValue = {
           name: partition.name,
-          budget: partition.budget ?? 0,
+          budget: partition.budget,
           parentPartitionGroupId: partition.parentPartitionGroupId,
           management: { ...partition.management }
         }
@@ -83,7 +83,7 @@ const createPartitionStore = defineStore('partition', {
       } catch {
         this.editedValue = {
           name: this.currentPartition.name,
-          budget: this.currentPartition.budget ?? 0,
+          budget: this.currentPartition.budget,
           parentPartitionGroupId: this.currentPartition.parentPartitionGroupId,
           management: { ...this.currentPartition.management }
         }


### PR DESCRIPTION
### **User description**
## 概要
- 取得・復旧時のeditedValueにおいて予算値をそのまま保持するよう修正
- API契約どおりnullを維持し既存データの意図しない0化を防止

## 動作確認
- npm run lint


___

### **PR Type**
Bug fix


___

### **Description**
- 予算フィールドのnullをそのまま保持

- 取得時と復旧時の0代入を削除

- 既存データの意図しない0化を防止


___

### Diagram Walkthrough


```mermaid
flowchart LR
  fetch["fetchPartition: API取得"] -- "budgetをそのまま設定(null許容)" --> editedValue1["editedValue初期化"]
  updateFail["更新失敗ハンドリング"] -- "currentPartitionのbudgetをそのまま設定" --> editedValue2["editedValue復旧"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>store.ts</strong><dd><code>予算null保持のための代入ロジック修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/features/partition/store.ts

<ul><li><code>editedValue.budget</code>から<code>?? 0</code>を削除<br> <li> 取得時: <code>partition.budget</code>をそのまま代入<br> <li> 復旧時: <code>currentPartition.budget</code>をそのまま代入<br> <li> null保持で意図しない0化を防止</ul>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/Jomon-UI/pull/619/files#diff-81795b8d8280ccf1fb7756f5e9f245ba3aea98719e45ca76700d0108fbe881b9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

