### PR TITLE
chore(formatting): `.prettierrc` から `filepath: none` を取り除く

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -15,7 +15,6 @@
   "bracketSameLine": true,
   "arrowParens": "avoid",
   "rangeStart": 0,
-  "filepath": "none",
   "requirePragma": false,
   "insertPragma": false,
   "proseWrap": "preserve",


### PR DESCRIPTION
format が変なやつを直しました
https://q.trap.jp/messages/019a59a2-b36c-7fb2-be4e-92ca4a983a17