### PR TITLE
refactor(store): migrate pinia stores to setup store syntax

### DIFF
--- a/src/features/application/store.ts
+++ b/src/features/application/store.ts
@@ -8,6 +8,7 @@ import type {
 import type { ApplicationStatus } from '@/features/applicationStatus/entities'
 import { useTagStore } from '@/features/tag/store'
 import { defineStore, storeToRefs } from 'pinia'
+import { computed, ref } from 'vue'
 
 const createDefaultParams = (): ApplicationQuerySeed => ({
   sort: 'created_at',
@@ -23,123 +24,145 @@ const createDefaultParams = (): ApplicationQuerySeed => ({
 
 const dateRule = /^2[0-9]{3}-[0-9]{1,2}-[0-9]{1,2}$/
 
-const createApplicationStore = defineStore('application', {
-  state: () => ({
-    applications: [] as Application[],
-    isApplicationFetched: false,
-    filterParams: createDefaultParams(),
-    currentApplication: null as ApplicationDetail | null
-  }),
-  getters: {
-    hasApplicationDetail: state => state.currentApplication !== null
-  },
-  actions: {
-    resetFilters() {
-      this.filterParams = createDefaultParams()
-    },
-    clearCurrentApplication() {
-      this.currentApplication = null
-    },
-    async fetchApplications() {
-      const repository = useApplicationRepository()
-      const { since, until } = this.filterParams
+const createApplicationStore = defineStore('application', () => {
+  const applications = ref<Application[]>([])
+  const isApplicationFetched = ref(false)
+  const filterParams = ref<ApplicationQuerySeed>(createDefaultParams())
+  const currentApplication = ref<ApplicationDetail | null>(null)
 
-      if (
-        (since && !dateRule.test(since)) ||
-        (until && !dateRule.test(until))
-      ) {
-        throw new Error('日付はyyyy-MM-ddの形式で入力してください')
-      }
+  const hasApplicationDetail = computed(() => currentApplication.value !== null)
 
-      try {
-        this.applications = await repository.fetchApplications(
-          this.filterParams
-        )
-        this.isApplicationFetched = true
-      } catch (e) {
-        throw new Error(
-          '申請一覧の取得に失敗しました: ' +
-            (e instanceof Error ? e.message : String(e))
-        )
-      }
-    },
-    async ensureApplication(id: string) {
-      if (this.currentApplication?.id === id) {
-        return this.currentApplication
-      }
-      return await this.fetchApplication(id)
-    },
-    async fetchApplication(id: string) {
-      const repository = useApplicationRepository()
-      try {
-        const application = await repository.fetchApplication(id)
-        this.currentApplication = application
-        return application
-      } catch {
-        throw new Error('申請の取得に失敗しました')
-      }
-    },
-    async createApplication(applicationSeed: ApplicationSeed) {
-      const repository = useApplicationRepository()
-      try {
-        const application = await repository.createApplication(applicationSeed)
-        this.applications.unshift(application)
-        return application
-      } catch {
-        throw new Error('申請の作成に失敗しました')
-      }
-    },
-    async editApplication(id: string, seed: ApplicationSeed) {
-      if (!this.currentApplication) return
+  const resetFilters = () => {
+    filterParams.value = createDefaultParams()
+  }
 
-      const tagStore = useTagStore()
-      const tags = await tagStore.ensureTags(seed.tags)
+  const clearCurrentApplication = () => {
+    currentApplication.value = null
+  }
 
-      const repository = useApplicationRepository()
-      try {
-        const updated = await repository.editApplication(id, { ...seed, tags })
-        this.currentApplication = updated
-        const index = this.applications.findIndex(app => app.id === updated.id)
-        if (index !== -1) {
-          this.applications.splice(index, 1, updated)
-        }
-      } catch {
-        throw new Error('申請の更新に失敗しました')
-      }
-    },
-    async createComment(id: string, comment: string) {
-      if (!this.currentApplication) return
+  const fetchApplications = async () => {
+    const repository = useApplicationRepository()
+    const { since, until } = filterParams.value
 
-      const repository = useApplicationRepository()
-      try {
-        const newComment = await repository.createComment(id, comment)
-        this.currentApplication.comments.push(newComment)
-      } catch {
-        throw new Error('コメントの作成に失敗しました')
-      }
-    },
-    async changeStatus(id: string, status: ApplicationStatus, comment: string) {
-      if (!this.currentApplication) return
-
-      const repository = useApplicationRepository()
-      try {
-        const res = await repository.editStatus(id, status, comment)
-        this.currentApplication.status = res.status
-        this.currentApplication.statuses.push(res)
-        const listIndex = this.applications.findIndex(app => app.id === id)
-        if (listIndex !== -1) {
-          this.applications[listIndex] = {
-            ...this.applications[listIndex],
-            status: res.status
-          }
-        }
-        if (res.comment !== undefined) {
-          this.currentApplication.comments.push(res.comment)
-        }
-      } catch {
-        throw new Error('ステータスの変更に失敗しました')
-      }
+    if ((since && !dateRule.test(since)) || (until && !dateRule.test(until))) {
+      throw new Error('日付はyyyy-MM-ddの形式で入力してください')
     }
+
+    try {
+      applications.value = await repository.fetchApplications(
+        filterParams.value
+      )
+      isApplicationFetched.value = true
+    } catch (e) {
+      throw new Error(
+        '申請一覧の取得に失敗しました: ' +
+          (e instanceof Error ? e.message : String(e))
+      )
+    }
+  }
+
+  const ensureApplication = async (id: string) => {
+    if (currentApplication.value?.id === id) {
+      return currentApplication.value
+    }
+    return await fetchApplication(id)
+  }
+
+  const fetchApplication = async (id: string) => {
+    const repository = useApplicationRepository()
+    try {
+      const application = await repository.fetchApplication(id)
+      currentApplication.value = application
+      return application
+    } catch {
+      throw new Error('申請の取得に失敗しました')
+    }
+  }
+
+  const createApplication = async (applicationSeed: ApplicationSeed) => {
+    const repository = useApplicationRepository()
+    try {
+      const application = await repository.createApplication(applicationSeed)
+      applications.value.unshift(application)
+      return application
+    } catch {
+      throw new Error('申請の作成に失敗しました')
+    }
+  }
+
+  const editApplication = async (id: string, seed: ApplicationSeed) => {
+    if (!currentApplication.value) return
+
+    const tagStore = useTagStore()
+    const tags = await tagStore.ensureTags(seed.tags)
+
+    const repository = useApplicationRepository()
+    try {
+      const updated = await repository.editApplication(id, { ...seed, tags })
+      currentApplication.value = updated
+      const index = applications.value.findIndex(app => app.id === updated.id)
+      if (index !== -1) {
+        applications.value.splice(index, 1, updated)
+      }
+    } catch {
+      throw new Error('申請の更新に失敗しました')
+    }
+  }
+
+  const createComment = async (id: string, comment: string) => {
+    if (!currentApplication.value) return
+
+    const repository = useApplicationRepository()
+    try {
+      const newComment = await repository.createComment(id, comment)
+      currentApplication.value.comments.push(newComment)
+    } catch {
+      throw new Error('コメントの作成に失敗しました')
+    }
+  }
+
+  const changeStatus = async (
+    id: string,
+    status: ApplicationStatus,
+    comment: string
+  ) => {
+    if (!currentApplication.value) return
+
+    const repository = useApplicationRepository()
+    try {
+      const res = await repository.editStatus(id, status, comment)
+      currentApplication.value.status = res.status
+      currentApplication.value.statuses.push(res)
+      const listIndex = applications.value.findIndex(app => app.id === id)
+      if (listIndex !== -1) {
+        applications.value[listIndex] = {
+          ...applications.value[listIndex],
+          status: res.status
+        }
+      }
+      if (res.comment !== undefined) {
+        currentApplication.value.comments.push(res.comment)
+      }
+    } catch {
+      throw new Error('ステータスの変更に失敗しました')
+    }
+  }
+
+  return {
+    applications,
+    isApplicationFetched,
+    filterParams,
+    currentApplication,
+    hasApplicationDetail,
+    resetFilters,
+    clearCurrentApplication,
+    fetchApplications,
+    ensureApplication,
+    fetchApplication,
+    createApplication,
+    editApplication,
+    createComment,
+    changeStatus
   }
 })
 
@@ -149,15 +172,15 @@ export const useApplicationStore = () => {
 
   return {
     ...refs,
-    resetFilters: store.resetFilters.bind(store),
-    clearCurrentApplication: store.clearCurrentApplication.bind(store),
-    fetchApplications: store.fetchApplications.bind(store),
-    ensureApplication: store.ensureApplication.bind(store),
-    fetchApplication: store.fetchApplication.bind(store),
-    createApplication: store.createApplication.bind(store),
-    editApplication: store.editApplication.bind(store),
-    createComment: store.createComment.bind(store),
-    changeStatus: store.changeStatus.bind(store)
+    resetFilters: store.resetFilters,
+    clearCurrentApplication: store.clearCurrentApplication,
+    fetchApplications: store.fetchApplications,
+    ensureApplication: store.ensureApplication,
+    fetchApplication: store.fetchApplication,
+    createApplication: store.createApplication,
+    editApplication: store.editApplication,
+    createComment: store.createComment,
+    changeStatus: store.changeStatus
   }
 }
 

--- a/tests/features/accountManager/store.spec.ts
+++ b/tests/features/accountManager/store.spec.ts
@@ -1,0 +1,116 @@
+import { useAccountManagerRepository } from '@/features/accountManager/data/repository'
+import { useAccountManagerStore } from '@/features/accountManager/store'
+import { useUserStore } from '@/features/user/store'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+
+// Mock repository
+vi.mock('@/features/accountManager/data/repository', () => ({
+  useAccountManagerRepository: vi.fn()
+}))
+
+// Mock user store
+vi.mock('@/features/user/store', () => ({
+  useUserStore: vi.fn()
+}))
+
+describe('AccountManager Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockAccountManagers = ['user-1', 'user-2']
+
+  describe('actions', () => {
+    it('fetchAccountManagers fetches managers and updates state', async () => {
+      const mockFetchAccountManagers = vi
+        .fn()
+        .mockResolvedValue(mockAccountManagers)
+      vi.mocked(useAccountManagerRepository).mockReturnValue({
+        fetchAccountManagers: mockFetchAccountManagers,
+        addAccountManagers: vi.fn(),
+        removeAccountManagers: vi.fn()
+      })
+
+      const store = useAccountManagerStore()
+      await store.fetchAccountManagers()
+
+      expect(mockFetchAccountManagers).toHaveBeenCalled()
+      expect(store.accountManagers.value).toEqual(mockAccountManagers)
+      expect(store.isAccountManagerFetched.value).toBe(true)
+    })
+
+    it('fetchAccountManagers handles error', async () => {
+      const mockFetchAccountManagers = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(useAccountManagerRepository).mockReturnValue({
+        fetchAccountManagers: mockFetchAccountManagers,
+        addAccountManagers: vi.fn(),
+        removeAccountManagers: vi.fn()
+      })
+
+      const store = useAccountManagerStore()
+      await expect(store.fetchAccountManagers()).rejects.toThrow(
+        '会計管理者の取得に失敗しました'
+      )
+    })
+
+    it('addAccountManagers adds managers and updates state', async () => {
+      const mockAddAccountManagers = vi.fn().mockResolvedValue(undefined)
+      vi.mocked(useAccountManagerRepository).mockReturnValue({
+        fetchAccountManagers: vi.fn(),
+        addAccountManagers: mockAddAccountManagers,
+        removeAccountManagers: vi.fn()
+      })
+
+      const store = useAccountManagerStore()
+      store.accountManagers.value = ['user-1']
+
+      await store.addAccountManagers(['user-2'])
+
+      expect(mockAddAccountManagers).toHaveBeenCalledWith(['user-2'])
+      expect(store.accountManagers.value).toEqual(['user-1', 'user-2'])
+    })
+
+    it('removeAccountManagers removes managers and updates state', async () => {
+      const mockRemoveAccountManagers = vi.fn().mockResolvedValue(undefined)
+      vi.mocked(useAccountManagerRepository).mockReturnValue({
+        fetchAccountManagers: vi.fn(),
+        addAccountManagers: vi.fn(),
+        removeAccountManagers: mockRemoveAccountManagers
+      })
+
+      const store = useAccountManagerStore()
+      store.accountManagers.value = ['user-1', 'user-2']
+
+      await store.removeAccountManagers(['user-1'])
+
+      expect(mockRemoveAccountManagers).toHaveBeenCalledWith(['user-1'])
+      expect(store.accountManagers.value).toEqual(['user-2'])
+    })
+  })
+
+  describe('getters', () => {
+    it('accountManagerOptions returns formatted options', () => {
+      const mockUserMap = {
+        'user-1': 'User 1',
+        'user-2': 'User 2'
+      }
+
+      vi.mocked(useUserStore).mockReturnValue({
+        userMap: computed(() => mockUserMap)
+      } as unknown as ReturnType<typeof useUserStore>)
+
+      const store = useAccountManagerStore()
+      store.accountManagers.value = ['user-1', 'user-2']
+
+      expect(store.accountManagerOptions.value).toEqual([
+        { key: 'User 1', value: 'user-1' },
+        { key: 'User 2', value: 'user-2' }
+      ])
+    })
+  })
+})

--- a/tests/features/application/store.spec.ts
+++ b/tests/features/application/store.spec.ts
@@ -1,0 +1,252 @@
+import { useApplicationRepository } from '@/features/application/data/repository'
+import type {
+  Application,
+  ApplicationDetail,
+  ApplicationSeed
+} from '@/features/application/entities'
+import { useApplicationStore } from '@/features/application/store'
+import type { ApplicationComment } from '@/features/applicationComment/entities'
+import type { ApplicationStatusDetail } from '@/features/applicationStatus/entities'
+import { useTagStore } from '@/features/tag/store'
+import { DateTime } from 'luxon'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock repository
+vi.mock('@/features/application/data/repository', () => ({
+  useApplicationRepository: vi.fn()
+}))
+
+// Mock tag store
+vi.mock('@/features/tag/store', () => ({
+  useTagStore: vi.fn()
+}))
+
+describe('Application Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockApplication: Application = {
+    id: 'app-1',
+    status: 'pending_review',
+    createdBy: 'user-1',
+    title: 'Test App',
+    content: 'Test Content',
+    targets: [],
+    tags: [],
+    partition: {
+      id: 'part-1',
+      name: 'Partition 1',
+      budget: 1000,
+      parentPartitionGroupId: 'group-1',
+      management: { category: 'manual', state: 'available' },
+      createdAt: '2023-01-01T00:00:00Z',
+      updatedAt: '2023-01-01T00:00:00Z'
+    },
+    createdAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
+    updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+  }
+
+  const mockApplicationDetail: ApplicationDetail = {
+    ...mockApplication,
+    files: [],
+    comments: [],
+    statuses: []
+  }
+
+  const mockSeed: ApplicationSeed = {
+    createdBy: 'user-1',
+    title: 'New App',
+    content: 'New Content',
+    tags: [],
+    partition: 'part-1',
+    targets: []
+  }
+
+  describe('actions', () => {
+    it('fetchApplications fetches applications and updates state', async () => {
+      const mockFetchApplications = vi.fn().mockResolvedValue([mockApplication])
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: mockFetchApplications,
+        fetchApplication: vi.fn(),
+        createApplication: vi.fn(),
+        editApplication: vi.fn(),
+        createComment: vi.fn(),
+        editStatus: vi.fn()
+      })
+
+      const store = useApplicationStore()
+      await store.fetchApplications()
+
+      expect(mockFetchApplications).toHaveBeenCalled()
+      expect(store.applications.value).toEqual([mockApplication])
+      expect(store.isApplicationFetched.value).toBe(true)
+    })
+
+    it('fetchApplications handles error', async () => {
+      const mockFetchApplications = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: mockFetchApplications,
+        fetchApplication: vi.fn(),
+        createApplication: vi.fn(),
+        editApplication: vi.fn(),
+        createComment: vi.fn(),
+        editStatus: vi.fn()
+      })
+
+      const store = useApplicationStore()
+      await expect(store.fetchApplications()).rejects.toThrow(
+        '申請一覧の取得に失敗しました'
+      )
+    })
+
+    it('fetchApplication fetches application detail and updates state', async () => {
+      const mockFetchApplication = vi
+        .fn()
+        .mockResolvedValue(mockApplicationDetail)
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: vi.fn(),
+        fetchApplication: mockFetchApplication,
+        createApplication: vi.fn(),
+        editApplication: vi.fn(),
+        createComment: vi.fn(),
+        editStatus: vi.fn()
+      })
+
+      const store = useApplicationStore()
+      await store.fetchApplication('app-1')
+
+      expect(mockFetchApplication).toHaveBeenCalledWith('app-1')
+      expect(store.currentApplication.value).toEqual(mockApplicationDetail)
+    })
+
+    it('createApplication creates application and adds to list', async () => {
+      const mockCreateApplication = vi
+        .fn()
+        .mockResolvedValue(mockApplicationDetail)
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: vi.fn(),
+        fetchApplication: vi.fn(),
+        createApplication: mockCreateApplication,
+        editApplication: vi.fn(),
+        createComment: vi.fn(),
+        editStatus: vi.fn()
+      })
+
+      const store = useApplicationStore()
+      await store.createApplication(mockSeed)
+
+      expect(mockCreateApplication).toHaveBeenCalledWith(mockSeed)
+      expect(store.applications.value[0]).toEqual(mockApplicationDetail)
+    })
+
+    it('editApplication updates application and list', async () => {
+      const mockUpdatedApp: ApplicationDetail = {
+        ...mockApplicationDetail,
+        title: 'Updated Title'
+      }
+      const mockEditApplication = vi.fn().mockResolvedValue(mockUpdatedApp)
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: vi.fn(),
+        fetchApplication: vi.fn(),
+        createApplication: vi.fn(),
+        editApplication: mockEditApplication,
+        createComment: vi.fn(),
+        editStatus: vi.fn()
+      })
+
+      vi.mocked(useTagStore).mockReturnValue({
+        ensureTags: vi.fn().mockResolvedValue([])
+      } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const store = useApplicationStore()
+      store.currentApplication.value = mockApplicationDetail
+      store.applications.value = [mockApplication]
+
+      await store.editApplication('app-1', mockSeed)
+
+      expect(mockEditApplication).toHaveBeenCalled()
+      expect(store.currentApplication.value).toEqual(mockUpdatedApp)
+      expect(store.applications.value[0]).toEqual(mockUpdatedApp)
+    })
+
+    it('createComment adds comment to current application', async () => {
+      const mockComment: ApplicationComment = {
+        id: 'comment-1',
+        comment: 'Test Comment',
+        user: 'user-1',
+        createdAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
+        updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+      }
+      const mockCreateComment = vi.fn().mockResolvedValue(mockComment)
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: vi.fn(),
+        fetchApplication: vi.fn(),
+        createApplication: vi.fn(),
+        editApplication: vi.fn(),
+        createComment: mockCreateComment,
+        editStatus: vi.fn()
+      })
+
+      const store = useApplicationStore()
+      store.currentApplication.value = mockApplicationDetail
+
+      await store.createComment('app-1', 'Test Comment')
+
+      expect(mockCreateComment).toHaveBeenCalledWith('app-1', 'Test Comment')
+      expect(store.currentApplication.value.comments).toContainEqual(
+        mockComment
+      )
+    })
+
+    it('changeStatus updates status and adds status log', async () => {
+      const mockStatusDetail: ApplicationStatusDetail = {
+        status: 'approved',
+        createdBy: 'user-1',
+        createdAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+      }
+      const mockEditStatus = vi.fn().mockResolvedValue(mockStatusDetail)
+      vi.mocked(useApplicationRepository).mockReturnValue({
+        fetchApplications: vi.fn(),
+        fetchApplication: vi.fn(),
+        createApplication: vi.fn(),
+        editApplication: vi.fn(),
+        createComment: vi.fn(),
+        editStatus: mockEditStatus
+      })
+
+      const store = useApplicationStore()
+      store.currentApplication.value = mockApplicationDetail
+      store.applications.value = [mockApplication]
+
+      await store.changeStatus('app-1', 'approved', 'Approved')
+
+      expect(mockEditStatus).toHaveBeenCalledWith(
+        'app-1',
+        'approved',
+        'Approved'
+      )
+      expect(store.currentApplication.value.status).toBe('approved')
+      expect(store.currentApplication.value.statuses).toContainEqual(
+        mockStatusDetail
+      )
+      expect(store.applications.value[0].status).toBe('approved')
+    })
+  })
+
+  describe('getters', () => {
+    it('hasApplicationDetail returns correct value', () => {
+      const store = useApplicationStore()
+
+      store.currentApplication.value = null
+      expect(store.hasApplicationDetail.value).toBe(false)
+
+      store.currentApplication.value = mockApplicationDetail
+      expect(store.hasApplicationDetail.value).toBe(true)
+    })
+  })
+})

--- a/tests/features/partition/store.spec.ts
+++ b/tests/features/partition/store.spec.ts
@@ -1,0 +1,173 @@
+import { usePartitionRepository } from '@/features/partition/data/repository'
+import type { Partition, PartitionSeed } from '@/features/partition/entities'
+import { usePartitionStore } from '@/features/partition/store'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock repository
+vi.mock('@/features/partition/data/repository', () => ({
+  usePartitionRepository: vi.fn()
+}))
+
+describe('Partition Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockPartition: Partition = {
+    id: 'partition-1',
+    name: 'Partition 1',
+    budget: 1000,
+    parentPartitionGroupId: 'group-1',
+    management: {
+      category: 'manual',
+      state: 'available'
+    },
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z'
+  }
+
+  const mockSeed: PartitionSeed = {
+    name: 'New Partition',
+    budget: 2000,
+    parentPartitionGroupId: 'group-1',
+    management: {
+      category: 'manual',
+      state: 'available'
+    }
+  }
+
+  describe('actions', () => {
+    it('fetchPartitions fetches partitions and updates state', async () => {
+      const mockFetchPartitions = vi.fn().mockResolvedValue([mockPartition])
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: mockFetchPartitions,
+        fetchPartition: vi.fn(),
+        createPartition: vi.fn(),
+        editPartition: vi.fn(),
+        deletePartition: vi.fn()
+      })
+
+      const store = usePartitionStore()
+      await store.fetchPartitions()
+
+      expect(mockFetchPartitions).toHaveBeenCalled()
+      expect(store.partitions.value).toEqual([mockPartition])
+      expect(store.isPartitionFetched.value).toBe(true)
+    })
+
+    it('fetchPartitions handles error', async () => {
+      const mockFetchPartitions = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: mockFetchPartitions,
+        fetchPartition: vi.fn(),
+        createPartition: vi.fn(),
+        editPartition: vi.fn(),
+        deletePartition: vi.fn()
+      })
+
+      const store = usePartitionStore()
+      await expect(store.fetchPartitions()).rejects.toThrow(
+        'パーティション一覧の取得に失敗しました'
+      )
+    })
+
+    it('fetchPartition fetches partition and updates state', async () => {
+      const mockFetchPartition = vi.fn().mockResolvedValue(mockPartition)
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: vi.fn(),
+        fetchPartition: mockFetchPartition,
+        createPartition: vi.fn(),
+        editPartition: vi.fn(),
+        deletePartition: vi.fn()
+      })
+
+      const store = usePartitionStore()
+      await store.fetchPartition('partition-1')
+
+      expect(mockFetchPartition).toHaveBeenCalledWith('partition-1')
+      expect(store.currentPartition.value).toEqual(mockPartition)
+      expect(store.editedValue.value).toEqual({
+        name: mockPartition.name,
+        budget: mockPartition.budget,
+        parentPartitionGroupId: mockPartition.parentPartitionGroupId,
+        management: mockPartition.management
+      })
+    })
+
+    it('createPartition creates partition and adds to list', async () => {
+      const mockCreatePartition = vi.fn().mockResolvedValue(mockPartition)
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: vi.fn(),
+        fetchPartition: vi.fn(),
+        createPartition: mockCreatePartition,
+        editPartition: vi.fn(),
+        deletePartition: vi.fn()
+      })
+
+      const store = usePartitionStore()
+      await store.createPartition(mockSeed)
+
+      expect(mockCreatePartition).toHaveBeenCalledWith(mockSeed)
+      expect(store.partitions.value[0]).toEqual(mockPartition)
+    })
+
+    it('editPartition updates partition and list', async () => {
+      const mockUpdatedPartition: Partition = {
+        ...mockPartition,
+        name: 'Updated Partition'
+      }
+      const mockEditPartition = vi.fn().mockResolvedValue(mockUpdatedPartition)
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: vi.fn(),
+        fetchPartition: vi.fn(),
+        createPartition: vi.fn(),
+        editPartition: mockEditPartition,
+        deletePartition: vi.fn()
+      })
+
+      const store = usePartitionStore()
+      store.currentPartition.value = mockPartition
+      store.partitions.value = [mockPartition]
+
+      await store.editPartition('partition-1', mockSeed)
+
+      expect(mockEditPartition).toHaveBeenCalledWith('partition-1', mockSeed)
+      expect(store.currentPartition.value).toEqual(mockUpdatedPartition)
+      expect(store.partitions.value[0]).toEqual(mockUpdatedPartition)
+    })
+
+    it('deletePartition deletes partition and removes from list', async () => {
+      const mockDeletePartition = vi.fn().mockResolvedValue(undefined)
+      vi.mocked(usePartitionRepository).mockReturnValue({
+        fetchPartitions: vi.fn(),
+        fetchPartition: vi.fn(),
+        createPartition: vi.fn(),
+        editPartition: vi.fn(),
+        deletePartition: mockDeletePartition
+      })
+
+      const store = usePartitionStore()
+      store.partitions.value = [mockPartition]
+
+      await store.deletePartition('partition-1')
+
+      expect(mockDeletePartition).toHaveBeenCalledWith('partition-1')
+      expect(store.partitions.value).toEqual([])
+    })
+  })
+
+  describe('getters', () => {
+    it('partitionOptions returns formatted options', () => {
+      const store = usePartitionStore()
+      store.partitions.value = [mockPartition]
+
+      expect(store.partitionOptions.value).toEqual([
+        { key: mockPartition.name, value: mockPartition.id }
+      ])
+    })
+  })
+})

--- a/tests/features/partitionGroup/store.spec.ts
+++ b/tests/features/partitionGroup/store.spec.ts
@@ -1,0 +1,191 @@
+import { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
+import type {
+  PartitionGroup,
+  PartitionGroupSeed
+} from '@/features/partitionGroup/entities'
+import { usePartitionGroupStore } from '@/features/partitionGroup/store'
+import type { User } from '@/features/user/entities'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock repository
+vi.mock('@/features/partitionGroup/data/repository', () => ({
+  usePartitionGroupRepository: vi.fn()
+}))
+
+describe('PartitionGroup Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockPartitionGroup: PartitionGroup = {
+    id: 'group-1',
+    name: 'Group 1',
+    parentPartitionGroupId: null,
+    depth: 0,
+    createdAt: '2023-01-01T00:00:00Z',
+    updatedAt: '2023-01-01T00:00:00Z'
+  }
+
+  const mockSeed: PartitionGroupSeed = {
+    name: 'New Group',
+    parentPartitionGroupId: null,
+    depth: 0
+  }
+
+  describe('actions', () => {
+    it('fetchPartitionGroups fetches groups and updates state', async () => {
+      const mockFetchPartitionGroups = vi
+        .fn()
+        .mockResolvedValue([mockPartitionGroup])
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: mockFetchPartitionGroups,
+        fetchPartitionGroup: vi.fn(),
+        createPartitionGroup: vi.fn(),
+        editPartitionGroup: vi.fn(),
+        deletePartitionGroup: vi.fn()
+      })
+
+      const store = usePartitionGroupStore()
+      await store.fetchPartitionGroups()
+
+      expect(mockFetchPartitionGroups).toHaveBeenCalled()
+      expect(store.partitionGroups.value).toEqual([mockPartitionGroup])
+      expect(store.isPartitionGroupFetched.value).toBe(true)
+    })
+
+    it('fetchPartitionGroups handles error', async () => {
+      const mockFetchPartitionGroups = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: mockFetchPartitionGroups,
+        fetchPartitionGroup: vi.fn(),
+        createPartitionGroup: vi.fn(),
+        editPartitionGroup: vi.fn(),
+        deletePartitionGroup: vi.fn()
+      })
+
+      const store = usePartitionGroupStore()
+      await expect(store.fetchPartitionGroups()).rejects.toThrow(
+        'パーティショングループ一覧の取得に失敗しました'
+      )
+    })
+
+    it('fetchPartitionGroup fetches group and updates state', async () => {
+      const mockFetchPartitionGroup = vi
+        .fn()
+        .mockResolvedValue(mockPartitionGroup)
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: vi.fn(),
+        fetchPartitionGroup: mockFetchPartitionGroup,
+        createPartitionGroup: vi.fn(),
+        editPartitionGroup: vi.fn(),
+        deletePartitionGroup: vi.fn()
+      })
+
+      const store = usePartitionGroupStore()
+      await store.fetchPartitionGroup('group-1')
+
+      expect(mockFetchPartitionGroup).toHaveBeenCalledWith('group-1')
+      expect(store.currentPartitionGroup.value).toEqual(mockPartitionGroup)
+      expect(store.editedValue.value).toEqual({
+        name: mockPartitionGroup.name,
+        parentPartitionGroupId: mockPartitionGroup.parentPartitionGroupId,
+        depth: mockPartitionGroup.depth
+      })
+    })
+
+    it('createPartitionGroup creates group and adds to list', async () => {
+      const mockCreatePartitionGroup = vi
+        .fn()
+        .mockResolvedValue(mockPartitionGroup)
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: vi.fn(),
+        fetchPartitionGroup: vi.fn(),
+        createPartitionGroup: mockCreatePartitionGroup,
+        editPartitionGroup: vi.fn(),
+        deletePartitionGroup: vi.fn()
+      })
+
+      const store = usePartitionGroupStore()
+      await store.createPartitionGroup(mockSeed)
+
+      expect(mockCreatePartitionGroup).toHaveBeenCalledWith(mockSeed)
+      expect(store.partitionGroups.value[0]).toEqual(mockPartitionGroup)
+    })
+
+    it('editPartitionGroup updates group and list', async () => {
+      const mockUpdatedGroup: PartitionGroup = {
+        ...mockPartitionGroup,
+        name: 'Updated Group'
+      }
+      const mockEditPartitionGroup = vi.fn().mockResolvedValue(mockUpdatedGroup)
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: vi.fn(),
+        fetchPartitionGroup: vi.fn(),
+        createPartitionGroup: vi.fn(),
+        editPartitionGroup: mockEditPartitionGroup,
+        deletePartitionGroup: vi.fn()
+      })
+
+      const store = usePartitionGroupStore()
+      store.currentPartitionGroup.value = mockPartitionGroup
+      store.partitionGroups.value = [mockPartitionGroup]
+
+      await store.editPartitionGroup('group-1', mockSeed)
+
+      expect(mockEditPartitionGroup).toHaveBeenCalledWith('group-1', mockSeed)
+      expect(store.currentPartitionGroup.value).toEqual(mockUpdatedGroup)
+      expect(store.partitionGroups.value[0]).toEqual(mockUpdatedGroup)
+    })
+
+    it('deletePartitionGroup deletes group and removes from list', async () => {
+      const mockDeletePartitionGroup = vi.fn().mockResolvedValue(undefined)
+      vi.mocked(usePartitionGroupRepository).mockReturnValue({
+        fetchPartitionGroups: vi.fn(),
+        fetchPartitionGroup: vi.fn(),
+        createPartitionGroup: vi.fn(),
+        editPartitionGroup: vi.fn(),
+        deletePartitionGroup: mockDeletePartitionGroup
+      })
+
+      const store = usePartitionGroupStore()
+      store.partitionGroups.value = [mockPartitionGroup]
+
+      await store.deletePartitionGroup('group-1')
+
+      expect(mockDeletePartitionGroup).toHaveBeenCalledWith('group-1')
+      expect(store.partitionGroups.value).toEqual([])
+    })
+  })
+
+  describe('getters', () => {
+    it('partitionGroupOptions returns formatted options', () => {
+      const store = usePartitionGroupStore()
+      store.partitionGroups.value = [mockPartitionGroup]
+
+      expect(store.partitionGroupOptions.value).toEqual([
+        { key: mockPartitionGroup.name, value: mockPartitionGroup.id }
+      ])
+    })
+
+    it('canEditPartitionGroup returns correct value', () => {
+      const store = usePartitionGroupStore()
+      const canEdit = store.canEditPartitionGroup.value
+
+      expect(canEdit(undefined)).toBe(false)
+      expect(canEdit({ accountManager: false } as User)).toBe(false)
+      expect(canEdit({ accountManager: true } as User)).toBe(true)
+    })
+
+    it('partitionGroupIdNameToMap returns id-name map', () => {
+      const store = usePartitionGroupStore()
+      store.partitionGroups.value = [mockPartitionGroup]
+
+      const map = store.partitionGroupIdNameToMap.value
+      expect(map.get(mockPartitionGroup.id)).toBe(mockPartitionGroup.name)
+    })
+  })
+})

--- a/tests/features/tag/store.spec.ts
+++ b/tests/features/tag/store.spec.ts
@@ -1,0 +1,117 @@
+import { useTagRepository } from '@/features/tag/data/repository'
+import type { Tag } from '@/features/tag/entities'
+import { useTagStore } from '@/features/tag/store'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock repository
+vi.mock('@/features/tag/data/repository', () => ({
+  useTagRepository: vi.fn()
+}))
+
+describe('Tag Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockTag: Tag = {
+    id: 'tag-1',
+    name: 'Tag 1'
+  }
+
+  describe('actions', () => {
+    it('fetchTags fetches tags and updates state', async () => {
+      const mockFetchTags = vi.fn().mockResolvedValue([mockTag])
+      vi.mocked(useTagRepository).mockReturnValue({
+        fetchTags: mockFetchTags,
+        createTag: vi.fn(),
+        deleteTag: vi.fn()
+      })
+
+      const store = useTagStore()
+      await store.fetchTags()
+
+      expect(mockFetchTags).toHaveBeenCalled()
+      expect(store.tags.value).toEqual([mockTag])
+      expect(store.isTagFetched.value).toBe(true)
+    })
+
+    it('fetchTags handles error', async () => {
+      const mockFetchTags = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(useTagRepository).mockReturnValue({
+        fetchTags: mockFetchTags,
+        createTag: vi.fn(),
+        deleteTag: vi.fn()
+      })
+
+      const store = useTagStore()
+      await expect(store.fetchTags()).rejects.toThrow(
+        'タグの取得に失敗しました'
+      )
+    })
+
+    it('ensureTags creates missing tags and returns all tags', async () => {
+      const existingTag: Tag = { id: 'tag-1', name: 'Existing' }
+      const newTag: Tag = { id: 'tag-2', name: 'New' }
+
+      const mockCreateTag = vi.fn().mockResolvedValue(newTag)
+      vi.mocked(useTagRepository).mockReturnValue({
+        fetchTags: vi.fn(),
+        createTag: mockCreateTag,
+        deleteTag: vi.fn()
+      })
+
+      const store = useTagStore()
+      store.tags.value = [existingTag]
+
+      const result = await store.ensureTags([
+        existingTag,
+        { id: '', name: 'New' } as Tag
+      ])
+
+      expect(mockCreateTag).toHaveBeenCalledWith('New')
+      expect(result).toEqual([existingTag, newTag])
+      expect(store.tags.value).toContainEqual(newTag)
+    })
+
+    it('deleteTags deletes tags and removes from list', async () => {
+      const mockDeleteTag = vi.fn().mockResolvedValue(undefined)
+      vi.mocked(useTagRepository).mockReturnValue({
+        fetchTags: vi.fn(),
+        createTag: vi.fn(),
+        deleteTag: mockDeleteTag
+      })
+
+      const store = useTagStore()
+      store.tags.value = [mockTag]
+
+      await store.deleteTags(['tag-1'])
+
+      expect(mockDeleteTag).toHaveBeenCalledWith('tag-1', 0, ['tag-1'])
+      expect(store.tags.value).toEqual([])
+    })
+  })
+
+  describe('getters', () => {
+    it('tagOptions returns formatted options', () => {
+      const store = useTagStore()
+      store.tags.value = [mockTag]
+
+      expect(store.tagOptions.value).toEqual([
+        { key: mockTag.name, value: mockTag }
+      ])
+    })
+
+    it('tagIdOptions returns formatted options with id', () => {
+      const store = useTagStore()
+      store.tags.value = [mockTag]
+
+      expect(store.tagIdOptions.value).toEqual([
+        { key: mockTag.name, value: mockTag.id }
+      ])
+    })
+  })
+})

--- a/tests/features/user/store.spec.ts
+++ b/tests/features/user/store.spec.ts
@@ -1,0 +1,157 @@
+import { useUserRepository } from '@/features/user/data/repository'
+import type { User } from '@/features/user/entities'
+import { useUserStore } from '@/features/user/store'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock repository
+vi.mock('@/features/user/data/repository', () => ({
+  useUserRepository: vi.fn()
+}))
+
+describe('User Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  const mockUser: User = {
+    id: 'user-1',
+    name: 'test-user',
+    displayName: 'Test User',
+    accountManager: false
+  }
+
+  const mockAdminUser: User = {
+    id: 'admin-1',
+    name: 'admin-user',
+    displayName: 'Admin User',
+    accountManager: true
+  }
+
+  describe('actions', () => {
+    it('fetchUsers fetches users and updates state', async () => {
+      const mockFetchUsers = vi
+        .fn()
+        .mockResolvedValue([mockUser, mockAdminUser])
+      vi.mocked(useUserRepository).mockReturnValue({
+        fetchUsers: mockFetchUsers,
+        fetchMe: vi.fn()
+      })
+
+      const store = useUserStore()
+      await store.fetchUsers()
+
+      expect(mockFetchUsers).toHaveBeenCalled()
+      expect(store.users.value).toEqual([mockUser, mockAdminUser])
+      expect(store.isUserFetched.value).toBe(true)
+    })
+
+    it('fetchUsers handles error', async () => {
+      const mockFetchUsers = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error'))
+      vi.mocked(useUserRepository).mockReturnValue({
+        fetchUsers: mockFetchUsers,
+        fetchMe: vi.fn()
+      })
+
+      const store = useUserStore()
+      await expect(store.fetchUsers()).rejects.toThrow(
+        'ユーザー一覧の取得に失敗しました'
+      )
+    })
+
+    it('fetchMe fetches current user and updates state', async () => {
+      const mockFetchMe = vi.fn().mockResolvedValue(mockUser)
+      vi.mocked(useUserRepository).mockReturnValue({
+        fetchUsers: vi.fn(),
+        fetchMe: mockFetchMe
+      })
+
+      const store = useUserStore()
+      await store.fetchMe()
+
+      expect(mockFetchMe).toHaveBeenCalled()
+      expect(store.me.value).toEqual(mockUser)
+      expect(store.isMeFetched.value).toBe(true)
+    })
+
+    it('fetchMe does not fetch if already fetched', async () => {
+      const mockFetchMe = vi.fn().mockResolvedValue(mockUser)
+      vi.mocked(useUserRepository).mockReturnValue({
+        fetchUsers: vi.fn(),
+        fetchMe: mockFetchMe
+      })
+
+      const store = useUserStore()
+      store.isMeFetched.value = true
+      await store.fetchMe()
+
+      expect(mockFetchMe).not.toHaveBeenCalled()
+    })
+
+    it('fetchMe handles error', async () => {
+      const mockFetchMe = vi.fn().mockRejectedValue(new Error('Network error'))
+      vi.mocked(useUserRepository).mockReturnValue({
+        fetchUsers: vi.fn(),
+        fetchMe: mockFetchMe
+      })
+
+      const store = useUserStore()
+      await expect(store.fetchMe()).rejects.toThrow(
+        'ユーザーの取得に失敗しました'
+      )
+    })
+
+    it('reset clears state', () => {
+      const store = useUserStore()
+      store.me.value = mockUser
+      store.users.value = [mockUser]
+      store.isUserFetched.value = true
+      store.isMeFetched.value = true
+
+      store.reset()
+
+      expect(store.me.value).toBeUndefined()
+      expect(store.users.value).toEqual([])
+      expect(store.isUserFetched.value).toBe(false)
+      expect(store.isMeFetched.value).toBe(false)
+    })
+  })
+
+  describe('getters', () => {
+    it('isAccountManager returns correct value', () => {
+      const store = useUserStore()
+
+      store.me.value = mockUser
+      expect(store.isAccountManager.value).toBe(false)
+
+      store.me.value = mockAdminUser
+      expect(store.isAccountManager.value).toBe(true)
+
+      store.me.value = undefined
+      expect(store.isAccountManager.value).toBe(false)
+    })
+
+    it('userOptions returns formatted options', () => {
+      const store = useUserStore()
+      store.users.value = [mockUser, mockAdminUser]
+
+      expect(store.userOptions.value).toEqual([
+        { key: mockUser.name, value: mockUser.id },
+        { key: mockAdminUser.name, value: mockAdminUser.id }
+      ])
+    })
+
+    it('userMap returns id-name map', () => {
+      const store = useUserStore()
+      store.users.value = [mockUser, mockAdminUser]
+
+      expect(store.userMap.value).toEqual({
+        [mockUser.id]: mockUser.name,
+        [mockAdminUser.id]: mockAdminUser.name
+      })
+    })
+  })
+})


### PR DESCRIPTION
## 概要
PiniaストアをOptions APIからSetup Store構文へ移行しました。

## 変更点
- 以下のストアをSetup Store構文に移行
    - User Store
    - Application Store
    - PartitionGroup Store
    - Tag Store
    - Partition Store
    - AccountManager Store
- 各ストアのユニットテストを追加
- \`use*Store\`ラッパーの\`.bind(store)\`を削除

## 検証
- \`npm run test:unit\`: 全テストパス
- \`npm run type-check\`: エラーなし
- \`npm run lint\`: エラーなし