### PR TITLE
refactor: migrate stores to use defineStoreComposable and DI

### DIFF
--- a/src/di.ts
+++ b/src/di.ts
@@ -1,0 +1,32 @@
+import type { useAccountManagerRepository } from '@/features/accountManager/data/repository'
+import type { useApplicationRepository } from '@/features/application/data/repository'
+import type { usePartitionRepository } from '@/features/partition/data/repository'
+import type { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
+import type { useTagRepository } from '@/features/tag/data/repository'
+import type { useUserRepository } from '@/features/user/data/repository'
+import type { InjectionKey } from 'vue'
+
+export type UserRepository = ReturnType<typeof useUserRepository>
+export type ApplicationRepository = ReturnType<typeof useApplicationRepository>
+export type PartitionRepository = ReturnType<typeof usePartitionRepository>
+export type PartitionGroupRepository = ReturnType<
+  typeof usePartitionGroupRepository
+>
+export type TagRepository = ReturnType<typeof useTagRepository>
+export type AccountManagerRepository = ReturnType<
+  typeof useAccountManagerRepository
+>
+
+export const UserRepositoryKey: InjectionKey<UserRepository> =
+  Symbol('UserRepository')
+export const ApplicationRepositoryKey: InjectionKey<ApplicationRepository> =
+  Symbol('ApplicationRepository')
+export const PartitionRepositoryKey: InjectionKey<PartitionRepository> = Symbol(
+  'PartitionRepository'
+)
+export const PartitionGroupRepositoryKey: InjectionKey<PartitionGroupRepository> =
+  Symbol('PartitionGroupRepository')
+export const TagRepositoryKey: InjectionKey<TagRepository> =
+  Symbol('TagRepository')
+export const AccountManagerRepositoryKey: InjectionKey<AccountManagerRepository> =
+  Symbol('AccountManagerRepository')

--- a/src/features/partitionGroup/store.ts
+++ b/src/features/partitionGroup/store.ts
@@ -1,8 +1,12 @@
-import { usePartitionGroupRepository } from './data/repository'
-import type { PartitionGroup, PartitionGroupSeed } from './entities'
+import { PartitionGroupRepositoryKey } from '@/di'
+import type {
+  PartitionGroup,
+  PartitionGroupSeed
+} from '@/features/partitionGroup/entities'
 import type { User } from '@/features/user/entities'
-import { defineStore, storeToRefs } from 'pinia'
-import { computed, ref } from 'vue'
+import { defineStoreComposable } from '@/lib/store'
+import type { AsyncStatus } from '@/types'
+import { computed, inject, ref } from 'vue'
 
 const createDefaultPartitionGroupSeed = (): PartitionGroupSeed => ({
   name: '',
@@ -10,140 +14,137 @@ const createDefaultPartitionGroupSeed = (): PartitionGroupSeed => ({
   depth: 0
 })
 
-const createPartitionGroupStore = defineStore('partitionGroup', () => {
-  const partitionGroups = ref<PartitionGroup[]>([])
-  const isPartitionGroupFetched = ref(false)
-  const currentPartitionGroup = ref<PartitionGroup | undefined>(undefined)
-  const editedValue = ref<PartitionGroupSeed>(createDefaultPartitionGroupSeed())
+export const usePartitionGroupStore = defineStoreComposable(
+  'partitionGroup',
+  () => {
+    const repository = inject(PartitionGroupRepositoryKey)
+    if (!repository) throw new Error('PartitionGroupRepository is not provided')
 
-  const partitionGroupOptions = computed(() =>
-    partitionGroups.value.map(group => ({
-      key: group.name,
-      value: group.id
-    }))
-  )
+    const partitionGroups = ref<PartitionGroup[]>([])
+    const status = ref<AsyncStatus>('idle')
+    const error = ref<string | null>(null)
+    const currentPartitionGroup = ref<PartitionGroup | undefined>(undefined)
+    const editedValue = ref<PartitionGroupSeed>(
+      createDefaultPartitionGroupSeed()
+    )
 
-  const canEditPartitionGroup = computed(() => (user: User | undefined) => {
-    if (!user) return false
-    return user.accountManager
-  })
+    const partitionGroupOptions = computed(() =>
+      partitionGroups.value.map(group => ({
+        key: group.name,
+        value: group.id
+      }))
+    )
 
-  const partitionGroupIdNameToMap = computed(() => {
-    return new Map(partitionGroups.value.map(group => [group.id, group.name]))
-  })
+    const canEditPartitionGroup = computed(() => (user: User | undefined) => {
+      if (!user) return false
+      return user.accountManager
+    })
 
-  const fetchPartitionGroups = async () => {
-    const repository = usePartitionGroupRepository()
-    try {
-      partitionGroups.value = await repository.fetchPartitionGroups()
-      isPartitionGroupFetched.value = true
-    } catch (e) {
-      throw new Error(
-        'パーティショングループ一覧の取得に失敗しました: ' +
+    const partitionGroupIdNameToMap = computed(() => {
+      return new Map(partitionGroups.value.map(group => [group.id, group.name]))
+    })
+
+    const isPartitionGroupFetched = computed(() => status.value === 'success')
+
+    const fetchPartitionGroups = async () => {
+      status.value = 'loading'
+      error.value = null
+
+      try {
+        partitionGroups.value = await repository.fetchPartitionGroups()
+        status.value = 'success'
+      } catch (e) {
+        status.value = 'error'
+        error.value =
+          'パーティショングループ一覧の取得に失敗しました: ' +
           (e instanceof Error ? e.message : String(e))
-      )
-    }
-  }
-
-  const fetchPartitionGroup = async (id: string) => {
-    const repository = usePartitionGroupRepository()
-    try {
-      const partitionGroup = await repository.fetchPartitionGroup(id)
-      currentPartitionGroup.value = partitionGroup
-      editedValue.value = {
-        name: partitionGroup.name,
-        parentPartitionGroupId: partitionGroup.parentPartitionGroupId,
-        depth: partitionGroup.depth
+        throw new Error(error.value)
       }
-    } catch {
-      throw new Error('パーティショングループの取得に失敗しました')
     }
-  }
 
-  const createPartitionGroup = async (partitionGroup: PartitionGroupSeed) => {
-    const repository = usePartitionGroupRepository()
-    try {
-      const res = await repository.createPartitionGroup(partitionGroup)
-      partitionGroups.value.unshift(res)
-    } catch {
-      throw new Error('パーティショングループの作成に失敗しました')
-    }
-  }
-
-  const editPartitionGroup = async (
-    id: string,
-    partitionGroupSeed: PartitionGroupSeed
-  ) => {
-    if (!currentPartitionGroup.value) return
-    const repository = usePartitionGroupRepository()
-    try {
-      const res = await repository.editPartitionGroup(id, partitionGroupSeed)
-      currentPartitionGroup.value = res
-      const index = partitionGroups.value.findIndex(
-        group => group.id === res.id
-      )
-      if (index !== -1) {
-        partitionGroups.value.splice(index, 1, res)
+    const fetchPartitionGroup = async (id: string) => {
+      try {
+        const partitionGroup = await repository.fetchPartitionGroup(id)
+        currentPartitionGroup.value = partitionGroup
+        editedValue.value = {
+          name: partitionGroup.name,
+          parentPartitionGroupId: partitionGroup.parentPartitionGroupId,
+          depth: partitionGroup.depth
+        }
+      } catch {
+        throw new Error('パーティショングループの取得に失敗しました')
       }
-    } catch {
-      editedValue.value = {
-        name: currentPartitionGroup.value.name,
-        parentPartitionGroupId:
-          currentPartitionGroup.value.parentPartitionGroupId,
-        depth: currentPartitionGroup.value.depth
+    }
+
+    const createPartitionGroup = async (partitionGroup: PartitionGroupSeed) => {
+      try {
+        const res = await repository.createPartitionGroup(partitionGroup)
+        partitionGroups.value.unshift(res)
+      } catch {
+        throw new Error('パーティショングループの作成に失敗しました')
       }
-      throw new Error('パーティショングループの更新に失敗しました')
+    }
+
+    const editPartitionGroup = async (
+      id: string,
+      partitionGroupSeed: PartitionGroupSeed
+    ) => {
+      if (!currentPartitionGroup.value) return
+      try {
+        const res = await repository.editPartitionGroup(id, partitionGroupSeed)
+        currentPartitionGroup.value = res
+        const index = partitionGroups.value.findIndex(
+          group => group.id === res.id
+        )
+        if (index !== -1) {
+          partitionGroups.value.splice(index, 1, res)
+        }
+      } catch {
+        editedValue.value = {
+          name: currentPartitionGroup.value.name,
+          parentPartitionGroupId:
+            currentPartitionGroup.value.parentPartitionGroupId,
+          depth: currentPartitionGroup.value.depth
+        }
+        throw new Error('パーティショングループの更新に失敗しました')
+      }
+    }
+
+    const deletePartitionGroup = async (id: string) => {
+      try {
+        await repository.deletePartitionGroup(id)
+        const index = partitionGroups.value.findIndex(group => group.id === id)
+        if (index !== -1) {
+          partitionGroups.value.splice(index, 1)
+        }
+      } catch {
+        throw new Error('パーティショングループの削除に失敗しました')
+      }
+    }
+
+    const resetDetail = () => {
+      currentPartitionGroup.value = undefined
+      editedValue.value = createDefaultPartitionGroupSeed()
+    }
+
+    return {
+      partitionGroups,
+      status,
+      error,
+      isPartitionGroupFetched,
+      currentPartitionGroup,
+      editedValue,
+      partitionGroupOptions,
+      canEditPartitionGroup,
+      partitionGroupIdNameToMap,
+      fetchPartitionGroups,
+      fetchPartitionGroup,
+      createPartitionGroup,
+      editPartitionGroup,
+      deletePartitionGroup,
+      resetDetail
     }
   }
-
-  const deletePartitionGroup = async (id: string) => {
-    const repository = usePartitionGroupRepository()
-    try {
-      await repository.deletePartitionGroup(id)
-      const index = partitionGroups.value.findIndex(group => group.id === id)
-      if (index !== -1) {
-        partitionGroups.value.splice(index, 1)
-      }
-    } catch {
-      throw new Error('パーティショングループの削除に失敗しました')
-    }
-  }
-
-  const resetDetail = () => {
-    currentPartitionGroup.value = undefined
-    editedValue.value = createDefaultPartitionGroupSeed()
-  }
-
-  return {
-    partitionGroups,
-    isPartitionGroupFetched,
-    currentPartitionGroup,
-    editedValue,
-    partitionGroupOptions,
-    canEditPartitionGroup,
-    partitionGroupIdNameToMap,
-    fetchPartitionGroups,
-    fetchPartitionGroup,
-    createPartitionGroup,
-    editPartitionGroup,
-    deletePartitionGroup,
-    resetDetail
-  }
-})
-
-export const usePartitionGroupStore = () => {
-  const store = createPartitionGroupStore()
-  const refs = storeToRefs(store)
-
-  return {
-    ...refs,
-    fetchPartitionGroups: store.fetchPartitionGroups,
-    fetchPartitionGroup: store.fetchPartitionGroup,
-    createPartitionGroup: store.createPartitionGroup,
-    editPartitionGroup: store.editPartitionGroup,
-    deletePartitionGroup: store.deletePartitionGroup,
-    resetDetail: store.resetDetail
-  }
-}
+)
 
 export type PartitionGroupStore = ReturnType<typeof usePartitionGroupStore>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,16 @@
+import { defineStore, storeToRefs } from 'pinia'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function defineStoreComposable<SS extends () => any>(
+  id: string,
+  storeSetup: SS
+): () => ReturnType<SS> {
+  const piniaStore = defineStore(id, storeSetup)
+
+  return () => {
+    const store = piniaStore()
+    const storeRefs = storeToRefs(store)
+
+    return { ...store, ...storeRefs } as ReturnType<SS>
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,19 @@
 import App from './App.vue'
+import {
+  AccountManagerRepositoryKey,
+  ApplicationRepositoryKey,
+  PartitionGroupRepositoryKey,
+  PartitionRepositoryKey,
+  TagRepositoryKey,
+  UserRepositoryKey
+} from './di'
 import router from './router'
+import { useAccountManagerRepository } from '@/features/accountManager/data/repository'
+import { useApplicationRepository } from '@/features/application/data/repository'
+import { usePartitionRepository } from '@/features/partition/data/repository'
+import { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
+import { useTagRepository } from '@/features/tag/data/repository'
+import { useUserRepository } from '@/features/user/data/repository'
 import { handlers } from '@/lib/msw'
 import { setupWorker } from 'msw/browser'
 import { createPinia } from 'pinia'
@@ -42,6 +56,13 @@ const options: PluginOptions = {
   hideProgressBar: true
 }
 
-await setup().then(app =>
+await setup().then(app => {
+  app.provide(UserRepositoryKey, useUserRepository())
+  app.provide(ApplicationRepositoryKey, useApplicationRepository())
+  app.provide(PartitionRepositoryKey, usePartitionRepository())
+  app.provide(PartitionGroupRepositoryKey, usePartitionGroupRepository())
+  app.provide(TagRepositoryKey, useTagRepository())
+  app.provide(AccountManagerRepositoryKey, useAccountManagerRepository())
+
   app.use(router).use(createPinia()).use(Toast, options).mount('#app')
-)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type AsyncStatus = 'idle' | 'loading' | 'success' | 'error'


### PR DESCRIPTION
## 概要
Pinia ストアのリファクタリングを行いました。
主な変更点は以下の通りです：

- \`defineStoreComposable\` ユーティリティの導入によるストア作成の標準化
- \`provide\`/\`inject\` を使用したリポジトリの Dependency Injection (DI) の実装
- ローディング状態の管理を \`boolean\` から \`AsyncStatus\` ('idle', 'loading', 'success', 'error') へ変更
- ストアへのエラー状態の追加
- ユニットテストの更新（\`app.provide\`, \`app.runWithContext\` の使用）
- \`ApplicationStore\` における \`useTagStore\` の依存関係解決の修正（トップレベルでの初期化）

## 変更されたストア
- UserStore
- ApplicationStore
- PartitionGroupStore
- TagStore
- PartitionStore
- AccountManagerStore

## 検証
- \`npm run test:unit\`: 全テストパス
- \`npm run type-check\`: エラーなし
- \`npm run lint\`: エラーなし