### PR TITLE
chore: standardize lint and format configuration

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: apis
           path: ./src/lib/apis/generated
-      - run: npm run lint:nofix -- --max-warnings=0
+      - run: npm run lint:ci
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,11 @@
 public/mockServiceWorker.js
 src/lib/apis/generated/**/*
 package-lock.json
+dist
+coverage
+*.log
+*.svg
+*.ico
+*.png
+*.jpg
+*.jpeg

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,16 +1,12 @@
 {
-  "plugins": [
-    "@trivago/prettier-plugin-sort-imports",
-    "prettier-plugin-tailwindcss"
-  ],
+  "singleQuote": true,
+  "trailingComma": "es5",
   "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,
   "semi": false,
-  "singleQuote": true,
   "quoteProps": "as-needed",
   "jsxSingleQuote": false,
-  "trailingComma": "none",
   "bracketSpacing": true,
   "bracketSameLine": true,
   "arrowParens": "avoid",
@@ -20,8 +16,23 @@
   "proseWrap": "preserve",
   "htmlWhitespaceSensitivity": "css",
   "vueIndentScriptAndStyle": false,
-  "endOfLine": "auto",
+  "endOfLine": "lf",
   "tailwindStylesheet": "./src/styles/main.css",
+  "plugins": [
+    "@trivago/prettier-plugin-sort-imports",
+    "prettier-plugin-tailwindcss"
+  ],
+  "importOrder": [
+    "^vue$",
+    "^pinia$",
+    "^vue-router$",
+    "<THIRD_PARTY_MODULES>",
+    "^@/lib/(.*)$",
+    "^@/(.*)$",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
   "overrides": [
     {
       "files": [".prettierrc", ".prettierrc.json"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,11 @@
 import pluginJs from '@eslint/js'
+import vitest from '@vitest/eslint-plugin'
+import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
 import {
   defineConfigWithVueTs,
-  vueTsConfigs
+  vueTsConfigs,
 } from '@vue/eslint-config-typescript'
-import eslintConfigPrettier from 'eslint-config-prettier'
+import unusedImports from 'eslint-plugin-unused-imports'
 import pluginVue from 'eslint-plugin-vue'
 import pluginVueA11y from 'eslint-plugin-vuejs-accessibility'
 import { defineConfig, globalIgnores } from 'eslint/config'
@@ -17,31 +19,48 @@ export default defineConfig([
   globalIgnores([
     '**/dist/**',
     'public/mockServiceWorker.js',
-    'src/lib/apis/generated/**'
+    'src/lib/apis/generated/**',
   ]),
   {
     files: ['src/**/*.{js,ts,tsx,vue}'],
     languageOptions: {
-      globals: globals.browser
-    }
+      globals: globals.browser,
+    },
+    plugins: {
+      'unused-imports': unusedImports,
+    },
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-imports': 'error',
+      'unused-imports/no-unused-vars': [
+        'warn',
+        {
+          vars: 'all',
+          varsIgnorePattern: '^_',
+          args: 'after-used',
+          argsIgnorePattern: '^_',
+        },
+      ],
+    },
   },
   {
     files: [
       'scripts/**/*.{js,mjs,cjs,ts,mts,cts}',
       'vite.config.ts',
       'vitest.config.ts',
-      '**/*.config.{js,mjs,cjs,ts,mts,cts}'
+      '**/*.config.{js,mjs,cjs,ts,mts,cts}',
     ],
     languageOptions: {
       globals: globals.node,
       parserOptions: {
         projectService: {
           defaultProject: './tsconfig.node.json',
-          allowDefaultProject: ['eslint.config.js', 'vitest.config.ts']
+          allowDefaultProject: ['eslint.config.js', 'vitest.config.ts'],
         },
-        tsconfigRootDir
-      }
-    }
+        tsconfigRootDir,
+      },
+    },
   },
   pluginJs.configs.recommended,
   ...defineConfigWithVueTs(
@@ -52,12 +71,11 @@ export default defineConfig([
       languageOptions: {
         parserOptions: {
           projectService: true,
-          tsconfigRootDir
-        }
-      }
+          tsconfigRootDir,
+        },
+      },
     },
     vueTsConfigs.strictTypeChecked,
-    vueTsConfigs.stylisticTypeChecked,
     {
       files: ['src/**/*.vue'],
       rules: {
@@ -66,26 +84,22 @@ export default defineConfig([
           'error',
           {
             required: {
-              some: ['nesting', 'id']
-            }
-          }
-        ]
-      }
+              some: ['nesting', 'id'],
+            },
+          },
+        ],
+      },
     }
   ),
   {
     files: ['tests/**/*.ts'],
+    ...vitest.configs.recommended,
     languageOptions: {
       globals: {
+        ...vitest.environments.env.globals,
         ...globals.node,
-        ...globals.jest
       },
-      parserOptions: {
-        project: './tsconfig.vitest.json',
-        projectService: false,
-        tsconfigRootDir
-      }
-    }
+    },
   },
-  eslintConfigPrettier
+  skipFormatting,
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
         "@vitejs/plugin-vue": "^6.0.1",
+        "@vitest/eslint-plugin": "^1.5.1",
         "@vue/compiler-sfc": "^3.5.6",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.6.0",
@@ -48,6 +49,8 @@
         "execa": "^9.6.0",
         "globals": "^16.4.0",
         "happy-dom": "^20.0.10",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.2.7",
         "msw": "^2.11.6",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.7.1",
@@ -2555,6 +2558,33 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.5.1.tgz",
+      "integrity": "sha512-t49CNERe/YadnLn90NTTKJLKzs99xBkXElcoUTLodG6j1G0Q7jy3mXqqiHd3N5aryG2KkgOg4UAoGwgwSrZqKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.46.1",
+        "@typescript-eslint/utils": "^8.46.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.8.tgz",
@@ -3464,6 +3494,69 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -3520,6 +3613,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3968,6 +4068,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -4721,6 +4834,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
@@ -5181,6 +5301,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5564,6 +5697,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -6677,6 +6826,144 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/load-esm": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
@@ -6738,6 +7025,189 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/lru-cache": {
@@ -6846,6 +7316,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -6967,6 +7450,19 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7411,6 +7907,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pinia": {
@@ -8194,6 +8703,52 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -8320,6 +8875,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -9103,6 +9668,7 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",
@@ -9531,6 +10097,20 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/yargs": {
@@ -11117,6 +11697,16 @@
         "@rolldown/pluginutils": "1.0.0-beta.29"
       }
     },
+    "@vitest/eslint-plugin": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.5.1.tgz",
+      "integrity": "sha512-t49CNERe/YadnLn90NTTKJLKzs99xBkXElcoUTLodG6j1G0Q7jy3mXqqiHd3N5aryG2KkgOg4UAoGwgwSrZqKQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "^8.46.1",
+        "@typescript-eslint/utils": "^8.46.1"
+      }
+    },
     "@vitest/expect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.8.tgz",
@@ -11758,6 +12348,43 @@
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true
     },
+    "cli-truncate": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
+      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^7.1.0",
+        "string-width": "^8.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+          "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+          "dev": true,
+          "requires": {
+            "get-east-asian-width": "^1.3.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -11800,6 +12427,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
     },
     "combined-stream": {
@@ -12110,6 +12743,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true
     },
     "es-abstract": {
       "version": "1.24.0",
@@ -12625,6 +13264,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
+    },
     "execa": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
@@ -12937,6 +13582,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -13199,6 +13850,12 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
       "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true
+    },
+    "husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true
     },
     "iconv-lite": {
@@ -13873,6 +14530,94 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "lint-staged": {
+      "version": "16.2.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
+      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "dev": true,
+      "requires": {
+        "commander": "^14.0.2",
+        "listr2": "^9.0.5",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^2.0.0",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "14.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+          "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+          "dev": true
+        }
+      }
+    },
+    "listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+          "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+          "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+          "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        }
+      }
+    },
     "load-esm": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
@@ -13908,6 +14653,113 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
+      }
+    },
+    "log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+          "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+          "dev": true,
+          "requires": {
+            "environment": "^1.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+          "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^5.0.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+          "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+          "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+          "dev": true,
+          "requires": {
+            "mimic-function": "^5.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+          "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^7.0.0",
+            "signal-exit": "^4.1.0"
+          }
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+          "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^10.3.0",
+            "get-east-asian-width": "^1.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+          "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.2.1",
+            "string-width": "^7.0.0",
+            "strip-ansi": "^7.1.0"
+          }
+        }
       }
     },
     "lru-cache": {
@@ -13985,6 +14837,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true
     },
     "minimatch": {
@@ -14069,6 +14927,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nano-spawn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
+      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
       "dev": true
     },
     "nanoid": {
@@ -14366,6 +15230,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true
     },
     "pinia": {
@@ -14835,6 +15705,33 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+          "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+          "dev": true,
+          "requires": {
+            "get-east-asian-width": "^1.3.1"
+          }
+        }
+      }
+    },
     "smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -14927,6 +15824,12 @@
       "requires": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true
     },
     "string-width": {
       "version": "4.2.3",
@@ -15420,6 +16323,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.8.tgz",
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",
@@ -15681,6 +16585,13 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "peer": true
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "jomon-ui",
   "version": "1.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "serve": "vite preview",
     "build": "vue-tsc --build && vite build",
     "build:watch": "vite build --watch",
-    "lint": "eslint --fix --cache .",
-    "lint:nofix": "eslint --cache .",
+    "lint": "eslint --fix --cache src tests scripts vite.config.ts vitest.config.ts eslint.config.js",
+    "lint:nofix": "eslint --cache src tests scripts vite.config.ts vitest.config.ts eslint.config.js",
+    "lint:ci": "eslint src tests scripts vite.config.ts vitest.config.ts eslint.config.js --max-warnings=0",
     "type-check": "vue-tsc --build --noEmit",
     "type-check:tests": "vue-tsc --project tsconfig.vitest.json --noEmit",
     "test:unit": "vitest run",
@@ -42,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
     "@vitejs/plugin-vue": "^6.0.1",
+    "@vitest/eslint-plugin": "^1.5.1",
     "@vue/compiler-sfc": "^3.5.6",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
@@ -58,6 +63,8 @@
     "execa": "^9.6.0",
     "globals": "^16.4.0",
     "happy-dom": "^20.0.10",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.7",
     "msw": "^2.11.6",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.7.1",
@@ -73,5 +80,11 @@
   },
   "msw": {
     "workerDirectory": "public"
+  },
+  "lint-staged": {
+    "*.{js,ts,tsx,vue,css,md,json,yml}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }

--- a/scripts/add-apis.ts
+++ b/scripts/add-apis.ts
@@ -22,7 +22,7 @@ const generateBaseAPI = async (sourceFile: SourceFile) => {
     name: 'Apis',
     extends: 'BaseAPI',
     methods: [...apiMethods.values()].map(m => m.getStructure()),
-    isExported: true
+    isExported: true,
   })
 
   await sourceFile.save()

--- a/scripts/add-ts-ignore-to-imports.ts
+++ b/scripts/add-ts-ignore-to-imports.ts
@@ -23,7 +23,7 @@ const addTsIgnoreToImportsToFile = async (sourceFile: SourceFile) => {
   sourceFile.applyTextChanges(
     insertPos.map(pos => ({
       span: { start: pos, length: 0 },
-      newText: '// @ts-ignore error happens by importsNotUsedAsValues\n'
+      newText: '// @ts-ignore error happens by importsNotUsedAsValues\n',
     }))
   )
 

--- a/scripts/generate-apis.ts
+++ b/scripts/generate-apis.ts
@@ -1,9 +1,10 @@
-import { addApis } from './add-apis.js'
-import { addTsIgnoreToImports } from './add-ts-ignore-to-imports.js'
 import { execa } from 'execa'
 import fs from 'fs/promises'
 import path from 'path'
 import { fileURLToPath } from 'url'
+
+import { addApis } from './add-apis.js'
+import { addTsIgnoreToImports } from './add-ts-ignore-to-imports.js'
 
 const SWAGGER_PATH =
   'https://raw.githubusercontent.com/traPtitech/Jomon/v2/docs/swagger.yaml'
@@ -17,7 +18,7 @@ const generateCmd = [
   '-i',
   SWAGGER_PATH,
   '-o',
-  GENERATED_DIR
+  GENERATED_DIR,
 ]
 
 const __filename = fileURLToPath(import.meta.url)
@@ -26,7 +27,7 @@ const __dirname = path.dirname(__filename)
 
 await (async () => {
   await fs.mkdir(path.resolve(__dirname, '../', GENERATED_DIR), {
-    recursive: true
+    recursive: true,
   })
 
   const p = execa('npx', generateCmd)

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
+import { watch } from 'vue'
+
+import { useRoute } from 'vue-router'
+
+import { useUserStore } from '@/features/user/store'
+
 import JomonHeader from './components/navigation/JomonHeader.vue'
 import './styles/main.css'
 import './styles/scrollbar.css'
 import './styles/toast.css'
-import { useUserStore } from '@/features/user/store'
-import { watch } from 'vue'
-import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const { fetchMe } = useUserStore()

--- a/src/components/applicationDetail/ApplicationContent.vue
+++ b/src/components/applicationDetail/ApplicationContent.vue
@@ -1,5 +1,10 @@
 <script lang="ts" setup>
-import ApplicationAttachment from './ApplicationAttachment.vue'
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
+import { formatDateAndTime } from '@/lib/date'
+
 import EditButton from '@/components/shared/EditButton.vue'
 import MarkdownIt from '@/components/shared/MarkdownIt.vue'
 import MarkdownTextarea from '@/components/shared/MarkdownTextarea.vue'
@@ -9,9 +14,8 @@ import { useApplication } from '@/features/application/composables'
 import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import { useUserStore } from '@/features/user/store'
-import { formatDateAndTime } from '@/lib/date'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
+
+import ApplicationAttachment from './ApplicationAttachment.vue'
 
 const props = defineProps<{
   application: ApplicationDetail
@@ -39,7 +43,7 @@ const handleUpdateContent = async () => {
     await editApplication(props.application.id, {
       ...props.application,
       partition: props.application.partition.id,
-      content: editedContent.value
+      content: editedContent.value,
     })
     toast.success('更新しました')
   } catch {

--- a/src/components/applicationDetail/ApplicationFiles.vue
+++ b/src/components/applicationDetail/ApplicationFiles.vue
@@ -1,10 +1,13 @@
 <script lang="ts" setup>
-import { useApplicationFile } from './composables/useApplicationFile'
-import SimpleButton from '@/components/shared/SimpleButton.vue'
-import { useApplicationStore } from '@/features/application/store'
-import { isImageByName } from '@/lib/checkFileType'
 import { DocumentIcon } from '@heroicons/vue/24/outline'
 import { XCircleIcon } from '@heroicons/vue/24/solid'
+
+import { isImageByName } from '@/lib/checkFileType'
+
+import SimpleButton from '@/components/shared/SimpleButton.vue'
+import { useApplicationStore } from '@/features/application/store'
+
+import { useApplicationFile } from './composables/useApplicationFile'
 
 const { currentApplication: application } = useApplicationStore()
 

--- a/src/components/applicationDetail/ApplicationHeader.vue
+++ b/src/components/applicationDetail/ApplicationHeader.vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
+
 import ApplicationStatusChange from '@/components/applicationDetail/ApplicationStatusChange.vue'
 import ApplicationTitle from '@/components/applicationDetail/ApplicationTitle.vue'
 import type { ApplicationDetail } from '@/features/application/entities'
-import { computed } from 'vue'
 
 const props = defineProps<{
   application: ApplicationDetail

--- a/src/components/applicationDetail/ApplicationLogs.vue
+++ b/src/components/applicationDetail/ApplicationLogs.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
-import CommentLog from './CommentLog.vue'
-import NewComment from './NewComment.vue'
-import StatusChangeLog from './StatusChangeLog.vue'
+import { computed } from 'vue'
+
 import ApplicationContent from '@/components/applicationDetail/ApplicationContent.vue'
 import type { ApplicationDetail } from '@/features/application/entities'
 import type { ApplicationComment } from '@/features/applicationComment/entities'
 import type { ApplicationStatusDetail } from '@/features/applicationStatus/entities'
-import { computed } from 'vue'
+
+import CommentLog from './CommentLog.vue'
+import NewComment from './NewComment.vue'
+import StatusChangeLog from './StatusChangeLog.vue'
 
 const props = defineProps<{
   application: ApplicationDetail
@@ -21,12 +23,12 @@ const logs = computed((): Log[] => {
   const comments: CommentWithType[] = props.application.comments.map(
     comment => ({
       ...comment,
-      type: 'comment'
+      type: 'comment',
     })
   )
   const statuses: StatusWithType[] = props.application.statuses.map(status => ({
     ...status,
-    type: 'statusChange'
+    type: 'statusChange',
   }))
 
   const logs = [...comments, ...statuses]

--- a/src/components/applicationDetail/ApplicationPartition.vue
+++ b/src/components/applicationDetail/ApplicationPartition.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import EditButton from '@/components/shared/EditButton.vue'
 import SearchSelect from '@/components/shared/SearchSelect.vue'
 import { useApplication } from '@/features/application/composables'
@@ -6,11 +10,9 @@ import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import { usePartitionStore } from '@/features/partition/store'
 import { useUserStore } from '@/features/user/store'
-import { computed, ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const application = defineModel<ApplicationDetail>('modelValue', {
-  required: true
+  required: true,
 })
 
 const { me } = useUserStore()
@@ -34,7 +36,7 @@ const handleUpdatePartition = async () => {
   try {
     await editApplication(application.value.id, {
       ...application.value,
-      partition: editedPartition.value
+      partition: editedPartition.value,
     })
     toast.success('更新しました')
   } catch {

--- a/src/components/applicationDetail/ApplicationStatusChange.vue
+++ b/src/components/applicationDetail/ApplicationStatusChange.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+
 import ModalWrapper from '@/components/modal/ModalWrapper.vue'
 import StatusChangeModal from '@/components/modal/StatusChangeModal.vue'
 import { useModal } from '@/components/modal/composables/useModal'
@@ -7,7 +9,6 @@ import StatusChip from '@/components/shared/StatusChip.vue'
 import type { ApplicationDetail } from '@/features/application/entities'
 import { useStatusOptions } from '@/features/applicationStatus/composables'
 import type { ApplicationStatus } from '@/features/applicationStatus/entities'
-import { ref } from 'vue'
 
 const props = defineProps<{
   application: ApplicationDetail

--- a/src/components/applicationDetail/ApplicationTags.vue
+++ b/src/components/applicationDetail/ApplicationTags.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import EditButton from '@/components/shared/EditButton.vue'
 import SearchSelectTag from '@/components/shared/SearchSelectTag.vue'
 import TagsPartition from '@/components/shared/TagsPartition.vue'
@@ -6,8 +10,6 @@ import { useApplication } from '@/features/application/composables'
 import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import { useUserStore } from '@/features/user/store'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const application = defineModel<ApplicationDetail>({ required: true })
 
@@ -26,7 +28,7 @@ const handleUpdateTags = async () => {
   try {
     await editApplication(application.value.id, {
       ...application.value,
-      partition: application.value.partition.id
+      partition: application.value.partition.id,
     })
     toast.success('更新しました')
   } catch {

--- a/src/components/applicationDetail/ApplicationTarget.vue
+++ b/src/components/applicationDetail/ApplicationTarget.vue
@@ -1,4 +1,9 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
+
+import { TrashIcon } from '@heroicons/vue/24/solid'
+import { useToast } from 'vue-toastification'
+
 import BaseNumberInput from '@/components/shared/BaseInput/BaseNumberInput.vue'
 import SearchSelect from '@/components/shared/SearchSelect.vue'
 import UserIcon from '@/components/shared/UserIcon.vue'
@@ -6,12 +11,9 @@ import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import type {
   ApplicationTarget,
-  ApplicationTargetDetail
+  ApplicationTargetDetail,
 } from '@/features/applicationTarget/entities'
 import { useUserStore } from '@/features/user/store'
-import { TrashIcon } from '@heroicons/vue/24/solid'
-import { computed } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const props = defineProps<{
   application: ApplicationDetail
@@ -56,7 +58,7 @@ const handleRemoveTarget = async () => {
       partition: props.application.partition.id,
       targets: props.application.targets.filter(
         target => target.id !== props.target.id
-      )
+      ),
     })
   } catch {
     toast.error('削除に失敗しました')

--- a/src/components/applicationDetail/ApplicationTargets.vue
+++ b/src/components/applicationDetail/ApplicationTargets.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import ApplicationTarget from '@/components/applicationDetail/ApplicationTarget.vue'
 import EditButton from '@/components/shared/EditButton.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
@@ -7,8 +11,6 @@ import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import type { ApplicationTargetDetail } from '@/features/applicationTarget/entities'
 import { useUserStore } from '@/features/user/store'
-import { computed, ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const props = defineProps<{
   application: ApplicationDetail
@@ -50,7 +52,7 @@ const handleUpdateTargets = async () => {
     await editApplication(props.application.id, {
       ...props.application,
       partition: props.application.partition.id,
-      targets: editedTargets.value
+      targets: editedTargets.value,
     })
     toast.success('更新しました')
   } catch {

--- a/src/components/applicationDetail/ApplicationTitle.vue
+++ b/src/components/applicationDetail/ApplicationTitle.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
 import EditButton from '@/components/shared/EditButton.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
@@ -6,8 +10,6 @@ import { useApplication } from '@/features/application/composables'
 import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import { useUserStore } from '@/features/user/store'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const props = defineProps<{
   application: ApplicationDetail
@@ -33,7 +35,7 @@ const handleUpdateTitle = async () => {
     await editApplication(props.application.id, {
       ...props.application,
       partition: props.application.partition.id,
-      title: editedTitle.value
+      title: editedTitle.value,
     })
     toast.success('更新しました')
   } catch {

--- a/src/components/applicationDetail/CommentLog.vue
+++ b/src/components/applicationDetail/CommentLog.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
+import { formatDateAndTime } from '@/lib/date'
+
 import MarkdownIt from '@/components/shared/MarkdownIt.vue'
 import UserIcon from '@/components/shared/UserIcon.vue'
 import type { ApplicationComment } from '@/features/applicationComment/entities'
 import { useUserStore } from '@/features/user/store'
-import { formatDateAndTime } from '@/lib/date'
 
 const props = defineProps<{
   comment: ApplicationComment

--- a/src/components/applicationDetail/StatusChangeLog.vue
+++ b/src/components/applicationDetail/StatusChangeLog.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
+import { formatDateAndTime } from '@/lib/date'
+
 import StatusChip from '@/components/shared/StatusChip.vue'
 import UserIcon from '@/components/shared/UserIcon.vue'
 import type { ApplicationStatusDetail } from '@/features/applicationStatus/entities'
 import { useUserStore } from '@/features/user/store'
-import { formatDateAndTime } from '@/lib/date'
 
 interface Props {
   log: ApplicationStatusDetail

--- a/src/components/applicationDetail/composables/useApplicationFile.ts
+++ b/src/components/applicationDetail/composables/useApplicationFile.ts
@@ -1,7 +1,9 @@
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import type { FileData } from '@/features/file/entities'
 import { deleteFile, fetchFilesWithMetas } from '@/features/file/services'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 export const useApplicationFile = () => {
   const toast = useToast()

--- a/src/components/applicationDetail/composables/useNewComment.ts
+++ b/src/components/applicationDetail/composables/useNewComment.ts
@@ -1,6 +1,8 @@
-import { useApplicationStore } from '@/features/application/store'
 import { ref } from 'vue'
+
 import { useToast } from 'vue-toastification'
+
+import { useApplicationStore } from '@/features/application/store'
 
 export const useNewComment = (applicationId: string) => {
   const toast = useToast()

--- a/src/components/applications/ApplicationFilters.vue
+++ b/src/components/applications/ApplicationFilters.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
+import { useToast } from 'vue-toastification'
+
 import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
 import SearchSelect from '@/components/shared/SearchSelect.vue'
 import { useApplicationStore } from '@/features/application/store'
@@ -6,8 +9,6 @@ import { applicationStatusOptions } from '@/features/applicationStatus/entities'
 import { usePartitionStore } from '@/features/partition/store'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
-import { useToast } from 'vue-toastification'
 
 const { applications, filterParams, fetchApplications } = useApplicationStore()
 const { userOptions } = useUserStore()

--- a/src/components/applications/ApplicationItem.vue
+++ b/src/components/applications/ApplicationItem.vue
@@ -1,12 +1,15 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
+
+import { RouterLink } from 'vue-router'
+
+import { formatDate } from '@/lib/date'
+
 import StatusChip from '@/components/shared/StatusChip.vue'
 import TagsPartition from '@/components/shared/TagsPartition.vue'
 import UserIcon from '@/components/shared/UserIcon.vue'
 import type { Application } from '@/features/application/entities'
 import { useUserStore } from '@/features/user/store'
-import { formatDate } from '@/lib/date'
-import { computed } from 'vue'
-import { RouterLink } from 'vue-router'
 
 interface Props {
   application: Application

--- a/src/components/modal/StatusChangeModal.vue
+++ b/src/components/modal/StatusChangeModal.vue
@@ -1,12 +1,14 @@
 <script lang="ts" setup>
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import MarkdownTextarea from '@/components/shared/MarkdownTextarea.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
 import StatusChip from '@/components/shared/StatusChip.vue'
 import type { ApplicationDetail } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import type { ApplicationStatus } from '@/features/applicationStatus/entities'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 const props = defineProps<{
   application: ApplicationDetail

--- a/src/components/navigation/JomonHeader.vue
+++ b/src/components/navigation/JomonHeader.vue
@@ -1,13 +1,16 @@
 <script lang="ts" setup>
-import PageNavigations from './PageNavigations.vue'
-import SideDrawer from './SideDrawer.vue'
+import { RouterLink } from 'vue-router'
+
+import { Bars3Icon } from '@heroicons/vue/24/outline'
+
 import ModalWrapper from '@/components/modal/ModalWrapper.vue'
 import { useModal } from '@/components/modal/composables/useModal'
 import JomonLogo from '@/components/shared/JomonLogo.vue'
 import UserIcon from '@/components/shared/UserIcon.vue'
 import { useUserStore } from '@/features/user/store'
-import { Bars3Icon } from '@heroicons/vue/24/outline'
-import { RouterLink } from 'vue-router'
+
+import PageNavigations from './PageNavigations.vue'
+import SideDrawer from './SideDrawer.vue'
 
 const { me } = useUserStore()
 

--- a/src/components/navigation/PageNavigations.vue
+++ b/src/components/navigation/PageNavigations.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import HeaderButton from './HeaderButton.vue'
-import { useUserStore } from '@/features/user/store'
 import { useRoute } from 'vue-router'
+
+import { useUserStore } from '@/features/user/store'
+
+import HeaderButton from './HeaderButton.vue'
 
 const { isAccountManager } = useUserStore()
 

--- a/src/components/newApplication/NewApplicationFileForm.vue
+++ b/src/components/newApplication/NewApplicationFileForm.vue
@@ -1,9 +1,12 @@
 <script lang="ts" setup>
-import type { FileSeed } from '@/features/file/entities'
-import { isImageByType } from '@/lib/checkFileType'
+import { ref } from 'vue'
+
 import { DocumentIcon } from '@heroicons/vue/24/outline'
 import { XCircleIcon } from '@heroicons/vue/24/solid'
-import { ref } from 'vue'
+
+import { isImageByType } from '@/lib/checkFileType'
+
+import type { FileSeed } from '@/features/file/entities'
 
 interface Props {
   files: FileSeed[]
@@ -24,7 +27,7 @@ function handleFileChange(e: Event) {
     reader.onload = () => {
       emit('input', [
         ...props.files,
-        { name: file.name, file: file } as FileSeed
+        { name: file.name, file: file } as FileSeed,
       ])
     }
   }

--- a/src/components/newApplication/NewApplicationTargets.vue
+++ b/src/components/newApplication/NewApplicationTargets.vue
@@ -1,10 +1,11 @@
 <script lang="ts" setup>
+import { PlusIcon, TrashIcon } from '@heroicons/vue/24/outline'
+
 import BaseNumberInput from '@/components/shared/BaseInput/BaseNumberInput.vue'
 import SearchSelect from '@/components/shared/SearchSelect.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
 import type { ApplicationTargetDraft } from '@/features/applicationTarget/entities'
 import { useUserStore } from '@/features/user/store'
-import { PlusIcon, TrashIcon } from '@heroicons/vue/24/outline'
 
 const model = defineModel<ApplicationTargetDraft[]>({ required: true })
 

--- a/src/components/partitionDetail/PartitionBudget.vue
+++ b/src/components/partitionDetail/PartitionBudget.vue
@@ -22,7 +22,7 @@ const { me } = useUserStore()
 const {
   canEditPartition,
   currentPartition: partition,
-  editedValue
+  editedValue,
 } = usePartitionStore()
 </script>
 

--- a/src/components/partitionDetail/PartitionGroup.vue
+++ b/src/components/partitionDetail/PartitionGroup.vue
@@ -22,7 +22,7 @@ const { me } = useUserStore()
 const {
   canEditPartition,
   currentPartition: partition,
-  editedValue
+  editedValue,
 } = usePartitionStore()
 const { partitionGroupIdNameToMap, partitionGroupOptions } =
   usePartitionGroupStore()

--- a/src/components/partitionDetail/PartitionName.vue
+++ b/src/components/partitionDetail/PartitionName.vue
@@ -21,7 +21,7 @@ const { me } = useUserStore()
 const {
   canEditPartition,
   currentPartition: partition,
-  editedValue
+  editedValue,
 } = usePartitionStore()
 </script>
 

--- a/src/components/partitionDetail/composables/useDeletePartition.ts
+++ b/src/components/partitionDetail/composables/useDeletePartition.ts
@@ -1,7 +1,10 @@
-import { usePartitionStore } from '@/features/partition/store'
 import { ref } from 'vue'
+
 import { useRouter } from 'vue-router'
+
 import { useToast } from 'vue-toastification'
+
+import { usePartitionStore } from '@/features/partition/store'
 
 export const useDeletePartition = () => {
   const router = useRouter()

--- a/src/components/partitionDetail/composables/usePartitionInformation.ts
+++ b/src/components/partitionDetail/composables/usePartitionInformation.ts
@@ -1,6 +1,8 @@
-import { usePartitionStore } from '@/features/partition/store'
 import { ref } from 'vue'
+
 import { useToast } from 'vue-toastification'
+
+import { usePartitionStore } from '@/features/partition/store'
 
 export type EditMode = 'name' | 'partitionGroup' | 'budget' | ''
 

--- a/src/components/partitions/PartitionTable.vue
+++ b/src/components/partitions/PartitionTable.vue
@@ -31,7 +31,7 @@ const navigateToPartition = async (partitionId: string) => {
           v-for="key in [
             'パーティション名',
             'パーティショングループ名',
-            '予算'
+            '予算',
           ]"
           :key="key"
           scope="col"

--- a/src/components/shared/BaseInput/BaseInputFrame.vue
+++ b/src/components/shared/BaseInput/BaseInputFrame.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
   isTextarea: false,
   hasValue: false,
   errorMessage: '',
-  errorMessageId: ''
+  errorMessageId: '',
 })
 
 const isFocused = ref(false)
@@ -56,7 +56,7 @@ const handleFocusOut = () => {
       'flex rounded-lg border border-surface-secondary ring-offset-2! transition-all duration-200 ease-in-out focus-within:ring-2! focus-within:ring-blue-500! focus-within:outline-none',
       readonly || disabled
         ? 'cursor-not-allowed bg-surface-secondary'
-        : 'bg-white'
+        : 'bg-white',
     ]"
     @focusin="handleFocusIn"
     @focusout="handleFocusOut">
@@ -68,7 +68,7 @@ const handleFocusOut = () => {
         :for="inputId"
         :class="[
           'pointer-events-none absolute left-3 text-text-secondary transition-all duration-200 ease-in-out peer-focus:text-blue-500',
-          labelPositionClass
+          labelPositionClass,
         ]">
         {{ label }}
         <span v-if="isRequired" class="text-red-500">*</span>

--- a/src/components/shared/BaseInput/BaseNumberInput.vue
+++ b/src/components/shared/BaseInput/BaseNumberInput.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import type { BaseInputCommonProps } from './BaseInput.types'
 import BaseInputFrame from './BaseInputFrame.vue'
 import { useBaseInput } from './useBaseInput'
-import { computed } from 'vue'
 
 interface Props extends BaseInputCommonProps {
   min?: number
@@ -18,7 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   step: 1,
   inputmode: 'decimal',
-  errorMessage: ''
+  errorMessage: '',
 })
 
 const model = defineModel<number | null>({ required: true })
@@ -93,7 +94,7 @@ const handleChange = (event: Event) => {
           inputProps.class,
           'w-full border-none bg-transparent px-3 pb-2 ring-0 outline-none not-focus-visible:placeholder:text-transparent',
           label ? 'pt-6' : 'pt-2',
-          readonly || disabled ? 'cursor-not-allowed' : ''
+          readonly || disabled ? 'cursor-not-allowed' : '',
         ]"
         :placeholder="placeholder"
         :readonly="readonly"

--- a/src/components/shared/BaseInput/BaseTextInput.vue
+++ b/src/components/shared/BaseInput/BaseTextInput.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import {
   type BaseInputCommonProps,
   type TextAutocomplete,
   type TextInputMode,
-  type TextInputType
+  type TextInputType,
 } from './BaseInput.types'
 import BaseInputFrame from './BaseInputFrame.vue'
 import { useBaseInput } from './useBaseInput'
-import { computed } from 'vue'
 
 interface Props extends BaseInputCommonProps {
   type?: TextInputType
@@ -25,7 +26,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   textarea: false,
   rows: 6,
-  errorMessage: ''
+  errorMessage: '',
 })
 
 const model = defineModel<string>({ required: true })
@@ -92,7 +93,7 @@ const handleChange = (event: Event) => {
           inputProps.class,
           'w-full border-none bg-transparent px-3 pb-2 ring-0 outline-none not-focus-visible:placeholder:text-transparent',
           label ? 'pt-6' : 'pt-2',
-          readonly || disabled ? 'cursor-not-allowed' : ''
+          readonly || disabled ? 'cursor-not-allowed' : '',
         ]"
         :placeholder="placeholder"
         :readonly="readonly"

--- a/src/components/shared/BaseInput/useBaseInput.ts
+++ b/src/components/shared/BaseInput/useBaseInput.ts
@@ -1,5 +1,6 @@
-import type { BaseInputCommonProps } from './BaseInput.types'
 import { computed, useId } from 'vue'
+
+import type { BaseInputCommonProps } from './BaseInput.types'
 
 type UseBaseInputProps = Pick<
   BaseInputCommonProps,
@@ -33,6 +34,6 @@ export function useBaseInput(props: UseBaseInputProps) {
     inputId,
     isFieldRequired,
     errorMessageId,
-    describedBy
+    describedBy,
   }
 }

--- a/src/components/shared/EditButton.vue
+++ b/src/components/shared/EditButton.vue
@@ -6,7 +6,7 @@ withDefaults(
     isEditMode?: boolean
   }>(),
   {
-    isEditMode: false
+    isEditMode: false,
   }
 )
 </script>

--- a/src/components/shared/InputCheckBox.vue
+++ b/src/components/shared/InputCheckBox.vue
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  required: false
+  required: false,
 })
 
 const model = defineModel<boolean>({ required: true })
@@ -29,7 +29,7 @@ const inputId = useId()
       <label
         :for="inputId"
         :class="[
-          'pointer-events-none absolute left-3 text-text-secondary transition-all duration-200 ease-in-out peer-focus:text-blue-500'
+          'pointer-events-none absolute left-3 text-text-secondary transition-all duration-200 ease-in-out peer-focus:text-blue-500',
         ]">
         {{ props.label }}
         <span v-if="props.required" class="text-red-500">*</span>

--- a/src/components/shared/MarkdownIt.vue
+++ b/src/components/shared/MarkdownIt.vue
@@ -9,7 +9,7 @@ const props = defineProps<Props>()
 
 const md = MarkdownIt({
   breaks: true,
-  linkify: true
+  linkify: true,
 })
 </script>
 

--- a/src/components/shared/MarkdownTextarea.vue
+++ b/src/components/shared/MarkdownTextarea.vue
@@ -1,9 +1,12 @@
 <script lang="ts" setup>
+import { computed, ref } from 'vue'
+
+import { EyeIcon, PencilSquareIcon } from '@heroicons/vue/24/outline'
+
+import SearchSelect from '@/components/shared/SearchSelect.vue'
+
 import BaseTextInput from './BaseInput/BaseTextInput.vue'
 import MarkdownIt from './MarkdownIt.vue'
-import SearchSelect from '@/components/shared/SearchSelect.vue'
-import { EyeIcon, PencilSquareIcon } from '@heroicons/vue/24/outline'
-import { computed, ref } from 'vue'
 
 type TabType = 'input' | 'preview'
 interface Props {
@@ -14,7 +17,7 @@ interface Props {
 
 const model = defineModel<string>({ required: true })
 const props = withDefaults(defineProps<Props>(), {
-  placeholder: ''
+  placeholder: '',
 })
 
 const currentTab = ref<TabType>('input')
@@ -25,7 +28,7 @@ const templateOptions = computed(
     props.templates?.map(template => {
       return {
         key: template.name,
-        value: template.name
+        value: template.name,
       }
     }) ?? []
 )

--- a/src/components/shared/PaginationBar.vue
+++ b/src/components/shared/PaginationBar.vue
@@ -1,7 +1,9 @@
 <script lang="ts" setup>
-import PageLink from './PageLink.vue'
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
 import { computed } from 'vue'
+
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
+
+import PageLink from './PageLink.vue'
 
 interface Props {
   path: string
@@ -47,7 +49,7 @@ const pages = computed(() => {
       ),
       [last - 1, last].filter(page => 1 <= page && page <= last)
     ),
-    mergePages([1], [current], [last])
+    mergePages([1], [current], [last]),
   ]
 })
 </script>

--- a/src/components/shared/SearchSelect.vue
+++ b/src/components/shared/SearchSelect.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import BaseTextInput from './BaseInput/BaseTextInput.vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+
 import {
   CheckIcon,
   ChevronDownIcon,
   MagnifyingGlassIcon,
   PlusIcon,
-  XMarkIcon
+  XMarkIcon,
 } from '@heroicons/vue/24/outline'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+
+import BaseTextInput from './BaseInput/BaseTextInput.vue'
 
 interface Option {
   key: string
@@ -30,7 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
   multiple: false,
   allowCustom: false,
   disabled: false,
-  required: false
+  required: false,
 })
 
 const emit = defineEmits<{
@@ -229,7 +231,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
         <ChevronDownIcon
           :class="[
             'h-4 w-4 text-text-secondary transition-transform',
-            menuState !== 'close' && 'rotate-180'
+            menuState !== 'close' && 'rotate-180',
           ]" />
       </button>
     </div>
@@ -266,7 +268,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
             'hover:bg-blue-100 hover:text-blue-500',
             highlightedIndex === index && 'bg-blue-100 text-blue-500',
             option.disabled && 'cursor-not-allowed opacity-50',
-            selectedValues.includes(option.value) && 'bg-blue-100'
+            selectedValues.includes(option.value) && 'bg-blue-100',
           ]"
           :disabled="option.disabled"
           @click="!option.disabled && handleSelect(option.value)">
@@ -293,7 +295,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
           type="button"
           :class="[
             'relative flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-left text-sm outline-none select-none',
-            'border-t hover:bg-blue-100 hover:text-blue-500'
+            'border-t hover:bg-blue-100 hover:text-blue-500',
           ]"
           @click="handleAddCustom">
           <PlusIcon class="mr-2 h-4 w-4" />

--- a/src/components/shared/SearchSelectTag.vue
+++ b/src/components/shared/SearchSelectTag.vue
@@ -1,8 +1,10 @@
 <script lang="ts" setup>
-import SearchSelect from './SearchSelect.vue'
+import { computed, ref, watch } from 'vue'
+
 import type { Tag } from '@/features/tag/entities'
 import { useTagStore } from '@/features/tag/store'
-import { computed, ref, watch } from 'vue'
+
+import SearchSelect from './SearchSelect.vue'
 
 const model = defineModel<Tag[]>({ required: true })
 
@@ -12,7 +14,7 @@ const selectedValue = ref(model.value.map(tag => tag.name))
 const searchOptions = computed(() =>
   tagOptions.value.map(tag => ({
     key: tag.key,
-    value: tag.value.name
+    value: tag.value.name,
   }))
 )
 
@@ -21,7 +23,7 @@ watch(selectedValue, () => {
     name =>
       tagOptions.value.find(tag => tag.value.name === name)?.value ?? {
         id: '',
-        name
+        name,
       }
   )
 })

--- a/src/components/shared/SimpleButton.vue
+++ b/src/components/shared/SimpleButton.vue
@@ -11,7 +11,7 @@ const props = withDefaults(defineProps<Props>(), {
   type: 'plain',
   disabled: false,
   fontSize: 'base',
-  padding: 'md'
+  padding: 'md',
 })
 
 const typeClass = computed(() => {

--- a/src/components/shared/StatusChip.vue
+++ b/src/components/shared/StatusChip.vue
@@ -1,14 +1,16 @@
 <script lang="ts" setup>
-import type { ApplicationStatus } from '@/features/applicationStatus/entities'
+import { computed } from 'vue'
+
 import {
   CheckCircleIcon,
   ChevronDownIcon,
   CloudArrowUpIcon,
   ExclamationTriangleIcon,
   HandThumbUpIcon,
-  XCircleIcon
+  XCircleIcon,
 } from '@heroicons/vue/24/solid'
-import { computed } from 'vue'
+
+import type { ApplicationStatus } from '@/features/applicationStatus/entities'
 
 interface Props {
   status: ApplicationStatus
@@ -18,7 +20,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   hasText: false,
-  hasMenu: false
+  hasMenu: false,
 })
 
 const statusToJpn = computed(() => (status: ApplicationStatus) => {

--- a/src/components/shared/UserIcon.vue
+++ b/src/components/shared/UserIcon.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
-import { UserCircleIcon } from '@heroicons/vue/24/solid'
 import { ref, watch } from 'vue'
+
+import { UserCircleIcon } from '@heroicons/vue/24/solid'
 
 const props = defineProps<{
   name?: string

--- a/src/di.ts
+++ b/src/di.ts
@@ -1,10 +1,11 @@
+import type { InjectionKey } from 'vue'
+
 import type { useAccountManagerRepository } from '@/features/accountManager/data/repository'
 import type { useApplicationRepository } from '@/features/application/data/repository'
 import type { usePartitionRepository } from '@/features/partition/data/repository'
 import type { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
 import type { useTagRepository } from '@/features/tag/data/repository'
 import type { useUserRepository } from '@/features/user/data/repository'
-import type { InjectionKey } from 'vue'
 
 export type UserRepository = ReturnType<typeof useUserRepository>
 export type ApplicationRepository = ReturnType<typeof useApplicationRepository>

--- a/src/features/accountManager/__mocks__/handlers.ts
+++ b/src/features/accountManager/__mocks__/handlers.ts
@@ -15,5 +15,5 @@ export const accountManagerHandlers = [
   ),
   http.delete('/api/account-managers', () => {
     return HttpResponse.json(null)
-  })
+  }),
 ]

--- a/src/features/accountManager/data/repository.ts
+++ b/src/features/accountManager/data/repository.ts
@@ -14,5 +14,5 @@ const createAccountManagerRepository = () => ({
   },
   removeAccountManagers: async (accountManagers: string[]) => {
     await apis.deleteAccountManagers(accountManagers)
-  }
+  },
 })

--- a/src/features/accountManager/store.ts
+++ b/src/features/accountManager/store.ts
@@ -1,8 +1,10 @@
+import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
 import { AccountManagerRepositoryKey } from '@/di'
 import { useUserStore } from '@/features/user/store'
-import { defineStoreComposable } from '@/lib/store'
 import type { AsyncStatus } from '@/types'
-import { computed, inject, ref } from 'vue'
 
 export const useAccountManagerStore = defineStoreComposable(
   'accountManager',
@@ -18,7 +20,7 @@ export const useAccountManagerStore = defineStoreComposable(
       const { getUserNameWithFallback } = useUserStore()
       return accountManagers.value.map(accountManager => ({
         key: getUserNameWithFallback(accountManager),
-        value: accountManager
+        value: accountManager,
       }))
     })
 
@@ -81,7 +83,7 @@ export const useAccountManagerStore = defineStoreComposable(
       fetchAccountManagers,
       addAccountManagers,
       removeAccountManagers,
-      reset
+      reset,
     }
   }
 )

--- a/src/features/application/__mocks__/handlers.ts
+++ b/src/features/application/__mocks__/handlers.ts
@@ -1,22 +1,24 @@
-import {
-  mockApplicationComment,
-  mockApplicationComments
-} from '@/features/applicationComment/__mocks__/handlers'
-import {
-  mockApplicationStatus,
-  mockApplicationStatuses
-} from '@/features/applicationStatus/__mocks__/handlers'
-import { mockApplicationTargets } from '@/features/applicationTarget/__mocks__/handlers'
-import { mockPartition } from '@/features/partition/__mocks__/handlers'
-import { mockTags } from '@/features/tag/__mocks__/handlers'
+import { HttpResponse, type PathParams, http } from 'msw'
+
 import type {
   Application,
   ApplicationDetail,
   Comment,
   CommentInput,
-  StatusDetail
+  StatusDetail,
 } from '@/lib/apis'
-import { http, HttpResponse, type PathParams } from 'msw'
+
+import {
+  mockApplicationComment,
+  mockApplicationComments,
+} from '@/features/applicationComment/__mocks__/handlers'
+import {
+  mockApplicationStatus,
+  mockApplicationStatuses,
+} from '@/features/applicationStatus/__mocks__/handlers'
+import { mockApplicationTargets } from '@/features/applicationTarget/__mocks__/handlers'
+import { mockPartition } from '@/features/partition/__mocks__/handlers'
+import { mockTags } from '@/features/tag/__mocks__/handlers'
 
 const mockApplication: Application = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -31,14 +33,14 @@ const mockApplication: Application = {
   - bbb`,
   targets: mockApplicationTargets,
   tags: mockTags,
-  partition: mockPartition
+  partition: mockPartition,
 }
 
 const mockApplicationDetail: ApplicationDetail = {
   ...mockApplication,
   comments: mockApplicationComments,
   statuses: mockApplicationStatuses,
-  files: ['3fa85f64-5717-4562-b3fc-2c963f66afa6']
+  files: ['3fa85f64-5717-4562-b3fc-2c963f66afa6'],
 }
 
 export const applicationHandlers = [
@@ -47,7 +49,7 @@ export const applicationHandlers = [
     const data = JSON.stringify(res)
 
     return new Response(data, {
-      status: 200
+      status: 200,
     })
   }),
   http.get('/api/applications/:id', () => {
@@ -60,7 +62,7 @@ export const applicationHandlers = [
       const reqBody: Application = await request.json()
       const res: ApplicationDetail = {
         ...mockApplicationDetail,
-        ...reqBody
+        ...reqBody,
       }
 
       return HttpResponse.json(res)
@@ -70,7 +72,7 @@ export const applicationHandlers = [
     // tagsの変換が必要なため、reqBodyを使っていない
     const res: ApplicationDetail = {
       ...mockApplicationDetail,
-      id: params.id as string // FIXME: 変換処理書く
+      id: params.id as string, // FIXME: 変換処理書く
     }
 
     return HttpResponse.json(res)
@@ -82,7 +84,7 @@ export const applicationHandlers = [
       const res: Comment = {
         ...mockApplicationComment,
         id: params.id as string,
-        ...reqBody
+        ...reqBody,
       }
 
       return HttpResponse.json(res)
@@ -93,5 +95,5 @@ export const applicationHandlers = [
     const res: StatusDetail = mockApplicationStatus
 
     return HttpResponse.json(res)
-  })
+  }),
 ]

--- a/src/features/application/composables.ts
+++ b/src/features/application/composables.ts
@@ -1,6 +1,8 @@
-import type { ApplicationDetail } from './entities'
-import type { User } from '@/features/user/entities'
 import { computed } from 'vue'
+
+import type { User } from '@/features/user/entities'
+
+import type { ApplicationDetail } from './entities'
 
 export const useApplication = (application: ApplicationDetail) => {
   const isApplicationCreator = computed(() => (user: User | undefined) => {

--- a/src/features/application/data/converter.ts
+++ b/src/features/application/data/converter.ts
@@ -1,13 +1,16 @@
-import type { Application, ApplicationDetail } from '../entities'
+import { DateTime } from 'luxon'
+
+import type {
+  Application as ApiApplication,
+  ApplicationDetail as ApiApplicationDetail,
+} from '@/lib/apis/generated/api'
+
 import { convertApplicationCommentFromData } from '@/features/applicationComment/data/converter'
 import { convertApplicationStatusDetailFromData } from '@/features/applicationStatus/data/converter'
 import { convertApplicationTargetFromData } from '@/features/applicationTarget/data/converter'
 import { convertPartitionFromData } from '@/features/partition/data/converter'
-import type {
-  Application as ApiApplication,
-  ApplicationDetail as ApiApplicationDetail
-} from '@/lib/apis/generated/api'
-import { DateTime } from 'luxon'
+
+import type { Application, ApplicationDetail } from '../entities'
 
 export const convertApplication = (
   application: ApiApplication
@@ -21,7 +24,7 @@ export const convertApplication = (
   tags: application.tags,
   partition: convertPartitionFromData(application.partition),
   createdAt: DateTime.fromISO(application.created_at),
-  updatedAt: DateTime.fromISO(application.updated_at)
+  updatedAt: DateTime.fromISO(application.updated_at),
 })
 
 export const convertApplicationDetail = (
@@ -39,5 +42,5 @@ export const convertApplicationDetail = (
   updatedAt: DateTime.fromISO(application.updated_at),
   files: application.files,
   comments: application.comments.map(convertApplicationCommentFromData),
-  statuses: application.statuses.map(convertApplicationStatusDetailFromData)
+  statuses: application.statuses.map(convertApplicationStatusDetailFromData),
 })

--- a/src/features/application/data/repository.ts
+++ b/src/features/application/data/repository.ts
@@ -1,23 +1,25 @@
-import type {
-  Application,
-  ApplicationDetail,
-  ApplicationQuerySeed,
-  ApplicationSeed
-} from '../entities'
-import { convertApplication, convertApplicationDetail } from './converter'
+import apis, {
+  type ApplicationInput,
+  type ApplicationTargetInput,
+  type CommentInput,
+  type StatusInput,
+} from '@/lib/apis'
+
 import { convertApplicationCommentFromData } from '@/features/applicationComment/data/converter'
 import type { ApplicationComment } from '@/features/applicationComment/entities'
 import { convertApplicationStatusDetailFromData } from '@/features/applicationStatus/data/converter'
 import type {
   ApplicationStatus,
-  ApplicationStatusDetail
+  ApplicationStatusDetail,
 } from '@/features/applicationStatus/entities'
-import apis, {
-  type ApplicationInput,
-  type ApplicationTargetInput,
-  type CommentInput,
-  type StatusInput
-} from '@/lib/apis'
+
+import type {
+  Application,
+  ApplicationDetail,
+  ApplicationQuerySeed,
+  ApplicationSeed,
+} from '../entities'
+import { convertApplication, convertApplicationDetail } from './converter'
 
 export const useApplicationRepository = () => {
   return createApplicationRepository()
@@ -27,7 +29,7 @@ const toApplicationTargetInput = (
   target: ApplicationSeed['targets'][number]
 ): ApplicationTargetInput => ({
   amount: target.amount,
-  target: target.target
+  target: target.target,
 })
 
 const toApplicationInput = (
@@ -38,11 +40,11 @@ const toApplicationInput = (
   content: application.content,
   tags: application.tags.map(tag => tag.id),
   partition: application.partition,
-  targets: application.targets.map(toApplicationTargetInput)
+  targets: application.targets.map(toApplicationTargetInput),
 })
 
 const toCommentInput = (comment: string): CommentInput => ({
-  comment
+  comment,
 })
 
 const toStatusInput = (
@@ -50,7 +52,7 @@ const toStatusInput = (
   comment: string
 ): StatusInput => ({
   status,
-  comment
+  comment,
 })
 
 const createApplicationRepository = () => ({
@@ -115,5 +117,5 @@ const createApplicationRepository = () => ({
     const { data } = await apis.putStatus(id, toStatusInput(status, comment))
 
     return convertApplicationStatusDetailFromData(data)
-  }
+  },
 })

--- a/src/features/application/entities.ts
+++ b/src/features/application/entities.ts
@@ -1,15 +1,16 @@
+import { DateTime } from 'luxon'
+
 import type { ApplicationComment } from '@/features/applicationComment/entities'
 import type {
   ApplicationStatus,
-  ApplicationStatusDetail
+  ApplicationStatusDetail,
 } from '@/features/applicationStatus/entities'
 import type {
   ApplicationTarget,
-  ApplicationTargetDetail
+  ApplicationTargetDetail,
 } from '@/features/applicationTarget/entities'
 import type { Partition } from '@/features/partition/entities'
 import type { Tag } from '@/features/tag/entities'
-import { DateTime } from 'luxon'
 
 export interface Application {
   id: string

--- a/src/features/application/store.ts
+++ b/src/features/application/store.ts
@@ -1,15 +1,17 @@
+import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
 import { ApplicationRepositoryKey } from '@/di'
 import type {
   Application,
   ApplicationDetail,
   ApplicationQuerySeed,
-  ApplicationSeed
+  ApplicationSeed,
 } from '@/features/application/entities'
 import type { ApplicationStatus } from '@/features/applicationStatus/entities'
 import { useTagStore } from '@/features/tag/store'
-import { defineStoreComposable } from '@/lib/store'
 import type { AsyncStatus } from '@/types'
-import { computed, inject, ref } from 'vue'
 
 const createDefaultParams = (): ApplicationQuerySeed => ({
   sort: 'created_at',
@@ -20,7 +22,7 @@ const createDefaultParams = (): ApplicationQuerySeed => ({
   limit: 10,
   offset: 0,
   tags: [],
-  partition: ''
+  partition: '',
 })
 
 const dateRule = /^2[0-9]{3}-[0-9]{1,2}-[0-9]{1,2}$/
@@ -167,7 +169,7 @@ export const useApplicationStore = defineStoreComposable('application', () => {
     createApplication,
     editApplication,
     createComment,
-    changeStatus
+    changeStatus,
   }
 })
 

--- a/src/features/applicationComment/__mocks__/handlers.ts
+++ b/src/features/applicationComment/__mocks__/handlers.ts
@@ -5,7 +5,7 @@ export const mockApplicationComment: Comment = {
   user: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   comment: '# aaaaa\n- aaa \n  - bbb',
   created_at: '2022-02-11T08:01:38.838Z',
-  updated_at: '2022-02-11T08:01:38.838Z'
+  updated_at: '2022-02-11T08:01:38.838Z',
 }
 
 export const mockApplicationComments: Comment[] = [
@@ -14,13 +14,13 @@ export const mockApplicationComments: Comment[] = [
     user: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     comment: '# aaaaa\n- aaa \n  - bbb',
     created_at: '2022-02-11T08:01:38.838Z',
-    updated_at: '2022-02-11T08:01:38.838Z'
+    updated_at: '2022-02-11T08:01:38.838Z',
   },
   {
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
     user: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     comment: '**コメント内容**',
     created_at: '2022-02-14T08:01:38.838Z',
-    updated_at: '2022-02-14T08:01:38.838Z'
-  }
+    updated_at: '2022-02-14T08:01:38.838Z',
+  },
 ]

--- a/src/features/applicationComment/data/converter.ts
+++ b/src/features/applicationComment/data/converter.ts
@@ -1,6 +1,8 @@
-import type { ApplicationComment } from '../entities'
-import type { Comment as CommentData } from '@/lib/apis'
 import { DateTime } from 'luxon'
+
+import type { Comment as CommentData } from '@/lib/apis'
+
+import type { ApplicationComment } from '../entities'
 
 export const convertApplicationCommentFromData = (
   comment: CommentData
@@ -9,5 +11,5 @@ export const convertApplicationCommentFromData = (
   user: comment.user,
   comment: comment.comment,
   createdAt: DateTime.fromISO(comment.created_at),
-  updatedAt: DateTime.fromISO(comment.updated_at)
+  updatedAt: DateTime.fromISO(comment.updated_at),
 })

--- a/src/features/applicationStatus/__mocks__/handlers.ts
+++ b/src/features/applicationStatus/__mocks__/handlers.ts
@@ -1,32 +1,33 @@
+import { HttpResponse, http } from 'msw'
+
 import type { Status } from '@/lib/apis'
-import { http, HttpResponse } from 'msw'
 
 export const mockApplicationStatus: Status = {
   created_by: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   status: 'pending_review',
-  created_at: '2022-02-12T08:01:37.838Z'
+  created_at: '2022-02-12T08:01:37.838Z',
 }
 
 export const mockApplicationStatuses: Status[] = [
   {
     created_by: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     status: 'pending_review',
-    created_at: '2022-02-12T08:01:37.838Z'
+    created_at: '2022-02-12T08:01:37.838Z',
   },
   {
     created_by: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     status: 'change_requested',
-    created_at: '2022-02-13T08:01:37.838Z'
+    created_at: '2022-02-13T08:01:37.838Z',
   },
   {
     created_by: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     status: 'pending_review',
-    created_at: '2022-02-18T08:01:37.838Z'
-  }
+    created_at: '2022-02-18T08:01:37.838Z',
+  },
 ]
 
 export const mockApplicationStatusHandlers = [
   http.put('/api/applications/:id/status', () => {
     return HttpResponse.json(mockApplicationStatus)
-  })
+  }),
 ]

--- a/src/features/applicationStatus/composables.ts
+++ b/src/features/applicationStatus/composables.ts
@@ -1,8 +1,9 @@
+import { computed } from 'vue'
+
 import { useApplication } from '@/features/application/composables'
 import type { ApplicationDetail } from '@/features/application/entities'
 import type { ApplicationStatus } from '@/features/applicationStatus/entities'
 import { useUserStore } from '@/features/user/store'
-import { computed } from 'vue'
 
 export const useStatusOptions = (application: ApplicationDetail) => {
   const { me, isAccountManager } = useUserStore()
@@ -28,16 +29,16 @@ export const useStatusOptions = (application: ApplicationDetail) => {
     {
       value: 'pending_review',
       key: '承認待ちにする',
-      show: showToPendingReview
+      show: showToPendingReview,
     },
     {
       value: 'change_requested',
       key: '要修正にする',
-      show: showToChangeRequested
+      show: showToChangeRequested,
     },
     { value: 'approved', key: '承認する', show: showToApproved },
     { value: 'rejected', key: '却下する', show: showToRejected },
-    { value: 'payment_finished', key: '支払い済み', show: showToPendingReview }
+    { value: 'payment_finished', key: '支払い済み', show: showToPendingReview },
   ])
   const showStatusOptions = computed(() =>
     statusOptions.value

--- a/src/features/applicationStatus/data/converter.ts
+++ b/src/features/applicationStatus/data/converter.ts
@@ -1,7 +1,10 @@
-import type { ApplicationStatusDetail } from '../entities'
-import { convertApplicationCommentFromData } from '@/features/applicationComment/data/converter'
-import type { StatusDetail as ApplicationStatusData } from '@/lib/apis'
 import { DateTime } from 'luxon'
+
+import type { StatusDetail as ApplicationStatusData } from '@/lib/apis'
+
+import { convertApplicationCommentFromData } from '@/features/applicationComment/data/converter'
+
+import type { ApplicationStatusDetail } from '../entities'
 
 export const convertApplicationStatusDetailFromData = (
   status: ApplicationStatusData
@@ -11,5 +14,5 @@ export const convertApplicationStatusDetailFromData = (
   comment: status.comment
     ? convertApplicationCommentFromData(status.comment)
     : undefined,
-  createdAt: DateTime.fromISO(status.created_at)
+  createdAt: DateTime.fromISO(status.created_at),
 })

--- a/src/features/applicationStatus/entities.ts
+++ b/src/features/applicationStatus/entities.ts
@@ -1,6 +1,8 @@
-import type { ApplicationComment } from '@/features/applicationComment/entities'
-import type { StatusEnum } from '@/lib/apis'
 import type { DateTime } from 'luxon'
+
+import type { StatusEnum } from '@/lib/apis'
+
+import type { ApplicationComment } from '@/features/applicationComment/entities'
 
 export interface ApplicationStatusDetail {
   createdBy: string
@@ -14,7 +16,7 @@ export const applicationStatusOptions = [
   { value: 'change_requested', key: '要修正' },
   { value: 'approved', key: '承認済み' },
   { value: 'rejected', key: '却下' },
-  { value: 'payment_finished', key: '支払い済み' }
+  { value: 'payment_finished', key: '支払い済み' },
 ] as const
 
 export type ApplicationStatus = (typeof StatusEnum)[keyof typeof StatusEnum]

--- a/src/features/applicationTarget/__mocks__/handlers.ts
+++ b/src/features/applicationTarget/__mocks__/handlers.ts
@@ -5,7 +5,7 @@ export const mockApplicationTarget: ApplicationTarget = {
   amount: 1200,
   target: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   paid_at: '2020-01-01',
-  created_at: '2020-01-01'
+  created_at: '2020-01-01',
 }
 
 export const mockApplicationTargets: ApplicationTarget[] = [
@@ -14,13 +14,13 @@ export const mockApplicationTargets: ApplicationTarget[] = [
     amount: 1200,
     target: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     paid_at: '2020-01-01',
-    created_at: '2020-01-01'
+    created_at: '2020-01-01',
   },
   {
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
     amount: 1500,
     target: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
     paid_at: null,
-    created_at: '2020-01-02'
-  }
+    created_at: '2020-01-02',
+  },
 ]

--- a/src/features/applicationTarget/data/converter.ts
+++ b/src/features/applicationTarget/data/converter.ts
@@ -1,6 +1,8 @@
-import type { ApplicationTargetDetail } from '../entities'
-import type { ApplicationTarget as ApplicationTargetData } from '@/lib/apis'
 import { DateTime } from 'luxon'
+
+import type { ApplicationTarget as ApplicationTargetData } from '@/lib/apis'
+
+import type { ApplicationTargetDetail } from '../entities'
 
 export const convertApplicationTargetFromData = (
   target: ApplicationTargetData
@@ -9,5 +11,5 @@ export const convertApplicationTargetFromData = (
   amount: target.amount,
   target: target.target,
   paidAt: target.paid_at,
-  createdAt: DateTime.fromISO(target.created_at)
+  createdAt: DateTime.fromISO(target.created_at),
 })

--- a/src/features/applicationTemplate/entities.ts
+++ b/src/features/applicationTemplate/entities.ts
@@ -3,7 +3,7 @@ import travelingExpenseApplicationTemplate from './travelingExpenseApplication.m
 
 export const applicationTemplates = [
   { name: '部費利用申請', value: clubBudgetApplicationTemplate },
-  { name: '交通費申請', value: travelingExpenseApplicationTemplate }
+  { name: '交通費申請', value: travelingExpenseApplicationTemplate },
 ] as const
 
 export type ApplicationTemplate = (typeof applicationTemplates)[number]['name']

--- a/src/features/file/__mocks__/handlers.ts
+++ b/src/features/file/__mocks__/handlers.ts
@@ -1,6 +1,8 @@
-import mehm8128 from '@/assets/mehm8128.png'
-import type { FileMeta } from '@/lib/apis'
 import { HttpResponse, http } from 'msw'
+
+import type { FileMeta } from '@/lib/apis'
+
+import mehm8128 from '@/assets/mehm8128.png'
 
 const mockFile = mehm8128
 
@@ -8,7 +10,7 @@ const mockFileMeta: FileMeta = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
   name: 'mehm8128.png',
   mime_type: 'image/png',
-  created_at: '2021-08-01T00:00:00Z'
+  created_at: '2021-08-01T00:00:00Z',
 }
 
 export const fileHandlers = [
@@ -22,5 +24,5 @@ export const fileHandlers = [
   }),
   http.post('/api/files', () => {
     return HttpResponse.json({ id: '3fa85f64-5717-4562-b3fc-2c963f66afa6' })
-  })
+  }),
 ]

--- a/src/features/file/data/converter.ts
+++ b/src/features/file/data/converter.ts
@@ -1,12 +1,14 @@
-import type { FileData, FileMeta } from '../entities'
-import type { FileMeta as FileMetaData } from '@/lib/apis'
 import { DateTime } from 'luxon'
+
+import type { FileMeta as FileMetaData } from '@/lib/apis'
+
+import type { FileData, FileMeta } from '../entities'
 
 export const convertFileMetaFromData = (fileMeta: FileMetaData): FileMeta => ({
   id: fileMeta.id,
   name: fileMeta.name,
   mimeType: fileMeta.mime_type,
-  createdAt: DateTime.fromISO(fileMeta.created_at)
+  createdAt: DateTime.fromISO(fileMeta.created_at),
 })
 
 export const convertFileAndMeta = (
@@ -21,6 +23,6 @@ export const convertFileAndMeta = (
     return {
       id: meta.id,
       file: file,
-      name: meta.name
+      name: meta.name,
     }
   })

--- a/src/features/file/data/repository.ts
+++ b/src/features/file/data/repository.ts
@@ -1,6 +1,7 @@
+import apis from '@/lib/apis'
+
 import type { FileMeta, FileSeed } from '../entities'
 import { convertFileMetaFromData } from './converter'
-import apis from '@/lib/apis'
 
 export const useFileRepository = () => {
   return createFileRepository()
@@ -24,5 +25,5 @@ const createFileRepository = () => ({
   },
   deleteFile: async (id: string) => {
     await apis.deleteFile(id)
-  }
+  },
 })

--- a/src/features/partition/__mocks__/handlers.ts
+++ b/src/features/partition/__mocks__/handlers.ts
@@ -1,6 +1,8 @@
-import type { PartitionSeed } from '../entities'
+import { HttpResponse, http } from 'msw'
+
 import type { Partition } from '@/lib/apis'
-import { http, HttpResponse } from 'msw'
+
+import type { PartitionSeed } from '../entities'
 
 export const mockPartition: Partition = {
   id: '1',
@@ -9,10 +11,10 @@ export const mockPartition: Partition = {
   parent_partition_group: 'group-1',
   management: {
     category: 'manual',
-    state: 'available'
+    state: 'available',
   },
   created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z'
+  updated_at: '2024-01-01T00:00:00Z',
 }
 export const mockPartitionWithoutBudget: Partition = {
   id: '2',
@@ -21,14 +23,14 @@ export const mockPartitionWithoutBudget: Partition = {
   parent_partition_group: 'group-2',
   management: {
     category: 'manual',
-    state: 'available'
+    state: 'available',
   },
   created_at: '2024-01-02T00:00:00Z',
-  updated_at: '2024-01-02T00:00:00Z'
+  updated_at: '2024-01-02T00:00:00Z',
 }
 const mockPartitions: Partition[] = [
   ...Array(5).fill(mockPartition),
-  ...Array(5).fill(mockPartitionWithoutBudget)
+  ...Array(5).fill(mockPartitionWithoutBudget),
 ]
 
 export const partitionHandlers = [
@@ -54,7 +56,7 @@ export const partitionHandlers = [
       budget: seed.budget,
       parent_partition_group:
         seed.parentPartitionGroupId || mockPartition.parent_partition_group,
-      management: seed.management
+      management: seed.management,
     }
     return HttpResponse.json(partition)
   }),
@@ -67,12 +69,12 @@ export const partitionHandlers = [
       budget: seed.budget,
       parent_partition_group:
         seed.parentPartitionGroupId || mockPartition.parent_partition_group,
-      management: seed.management
+      management: seed.management,
     }
     return HttpResponse.json(partition)
   }),
 
   http.delete('/api/partitions/:id', () => {
     return new HttpResponse(null, { status: 204 })
-  })
+  }),
 ]

--- a/src/features/partition/data/converter.ts
+++ b/src/features/partition/data/converter.ts
@@ -1,5 +1,6 @@
-import type { Partition } from '../entities'
 import type { Partition as ApiPartition } from '@/lib/apis'
+
+import type { Partition } from '../entities'
 
 export const convertPartitionFromData = (
   partition: ApiPartition
@@ -10,8 +11,8 @@ export const convertPartitionFromData = (
   parentPartitionGroupId: partition.parent_partition_group,
   management: {
     category: partition.management.category,
-    state: partition.management.state
+    state: partition.management.state,
   },
   createdAt: partition.created_at,
-  updatedAt: partition.updated_at
+  updatedAt: partition.updated_at,
 })

--- a/src/features/partition/data/repository.ts
+++ b/src/features/partition/data/repository.ts
@@ -1,6 +1,7 @@
-import type { PartitionSeed, Partition } from '../entities'
-import { convertPartitionFromData } from './converter'
 import apis, { type PartitionInput } from '@/lib/apis'
+
+import type { Partition, PartitionSeed } from '../entities'
+import { convertPartitionFromData } from './converter'
 
 export const usePartitionRepository = () => {
   return createPartitionRepository()
@@ -10,7 +11,7 @@ const toPartitionInput = (partition: PartitionSeed): PartitionInput => ({
   name: partition.name,
   budget: partition.budget,
   parent_partition_group: partition.parentPartitionGroupId,
-  management: partition.management
+  management: partition.management,
 })
 
 const createPartitionRepository = () => ({
@@ -37,5 +38,5 @@ const createPartitionRepository = () => ({
   },
   deletePartition: async (id: string) => {
     await apis.deletePartition(id)
-  }
+  },
 })

--- a/src/features/partition/store.ts
+++ b/src/features/partition/store.ts
@@ -1,9 +1,12 @@
-import type { Partition, PartitionSeed } from './entities'
+import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
 import { PartitionRepositoryKey } from '@/di'
 import type { User } from '@/features/user/entities'
-import { defineStoreComposable } from '@/lib/store'
 import type { AsyncStatus } from '@/types'
-import { computed, inject, ref } from 'vue'
+
+import type { Partition, PartitionSeed } from './entities'
 
 const createDefaultPartitionSeed = (): PartitionSeed => ({
   name: '',
@@ -11,8 +14,8 @@ const createDefaultPartitionSeed = (): PartitionSeed => ({
   parentPartitionGroupId: '',
   management: {
     category: 'manual',
-    state: 'available'
-  }
+    state: 'available',
+  },
 })
 
 export const usePartitionStore = defineStoreComposable('partition', () => {
@@ -28,7 +31,7 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
   const partitionOptions = computed(() =>
     partitions.value.map(partition => ({
       key: partition.name,
-      value: partition.id
+      value: partition.id,
     }))
   )
 
@@ -63,7 +66,7 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
         name: partition.name,
         budget: partition.budget,
         parentPartitionGroupId: partition.parentPartitionGroupId,
-        management: { ...partition.management }
+        management: { ...partition.management },
       }
     } catch {
       throw new Error('パーティションの取得に失敗しました')
@@ -95,7 +98,7 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
         name: currentPartition.value.name,
         budget: currentPartition.value.budget,
         parentPartitionGroupId: currentPartition.value.parentPartitionGroupId,
-        management: { ...currentPartition.value.management }
+        management: { ...currentPartition.value.management },
       }
       throw new Error('パーティションの更新に失敗しました')
     }
@@ -132,7 +135,7 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
     createPartition,
     editPartition,
     deletePartition,
-    resetDetail
+    resetDetail,
   }
 })
 

--- a/src/features/partitionGroup/__mocks__/handlers.ts
+++ b/src/features/partitionGroup/__mocks__/handlers.ts
@@ -1,6 +1,8 @@
-import type { PartitionGroupSeed } from '../entities'
+import { HttpResponse, http } from 'msw'
+
 import type { PartitionGroup } from '@/lib/apis'
-import { http, HttpResponse } from 'msw'
+
+import type { PartitionGroupSeed } from '../entities'
 
 export const mockPartitionGroup: PartitionGroup = {
   id: 'group-1',
@@ -8,7 +10,7 @@ export const mockPartitionGroup: PartitionGroup = {
   parent_partition_group: null,
   depth: 1,
   created_at: '2024-01-01T00:00:00Z',
-  updated_at: '2024-01-01T00:00:00Z'
+  updated_at: '2024-01-01T00:00:00Z',
 }
 
 const mockPartitionGroups = Array(10).fill(mockPartitionGroup)
@@ -31,7 +33,7 @@ export const partitionGroupHandlers = [
       ...mockPartitionGroup,
       name: seed.name,
       parent_partition_group: seed.parentPartitionGroupId,
-      depth: seed.depth
+      depth: seed.depth,
     }
     return HttpResponse.json(partitionGroup)
   }),
@@ -42,12 +44,12 @@ export const partitionGroupHandlers = [
       ...mockPartitionGroup,
       name: seed.name,
       parent_partition_group: seed.parentPartitionGroupId,
-      depth: seed.depth
+      depth: seed.depth,
     }
     return HttpResponse.json(partitionGroup)
   }),
 
   http.delete('/api/partition-groups/:id', () => {
     return new HttpResponse(null, { status: 204 })
-  })
+  }),
 ]

--- a/src/features/partitionGroup/data/converter.ts
+++ b/src/features/partitionGroup/data/converter.ts
@@ -1,5 +1,6 @@
-import type { PartitionGroup } from '../entities'
 import type { PartitionGroup as ApiPartitionGroup } from '@/lib/apis'
+
+import type { PartitionGroup } from '../entities'
 
 export const convertPartitionGroupFromData = (
   partitionGroup: ApiPartitionGroup
@@ -9,5 +10,5 @@ export const convertPartitionGroupFromData = (
   parentPartitionGroupId: partitionGroup.parent_partition_group,
   depth: partitionGroup.depth,
   createdAt: partitionGroup.created_at,
-  updatedAt: partitionGroup.updated_at
+  updatedAt: partitionGroup.updated_at,
 })

--- a/src/features/partitionGroup/data/repository.ts
+++ b/src/features/partitionGroup/data/repository.ts
@@ -1,6 +1,7 @@
+import apis, { type PartitionGroupInput } from '@/lib/apis'
+
 import type { PartitionGroup, PartitionGroupSeed } from '../entities'
 import { convertPartitionGroupFromData } from './converter'
-import apis, { type PartitionGroupInput } from '@/lib/apis'
 
 export const usePartitionGroupRepository = () => {
   return createPartitionGroupRepository()
@@ -11,7 +12,7 @@ const toPartitionGroupInput = (
 ): PartitionGroupInput => ({
   name: partitionGroup.name,
   parent_partition_group: partitionGroup.parentPartitionGroupId,
-  depth: partitionGroup.depth
+  depth: partitionGroup.depth,
 })
 
 const createPartitionGroupRepository = () => ({
@@ -45,5 +46,5 @@ const createPartitionGroupRepository = () => ({
   },
   deletePartitionGroup: async (id: string) => {
     await apis.deletePartitionGroup(id)
-  }
+  },
 })

--- a/src/features/partitionGroup/store.ts
+++ b/src/features/partitionGroup/store.ts
@@ -1,17 +1,19 @@
+import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
 import { PartitionGroupRepositoryKey } from '@/di'
 import type {
   PartitionGroup,
-  PartitionGroupSeed
+  PartitionGroupSeed,
 } from '@/features/partitionGroup/entities'
 import type { User } from '@/features/user/entities'
-import { defineStoreComposable } from '@/lib/store'
 import type { AsyncStatus } from '@/types'
-import { computed, inject, ref } from 'vue'
 
 const createDefaultPartitionGroupSeed = (): PartitionGroupSeed => ({
   name: '',
   parentPartitionGroupId: null,
-  depth: 0
+  depth: 0,
 })
 
 export const usePartitionGroupStore = defineStoreComposable(
@@ -31,7 +33,7 @@ export const usePartitionGroupStore = defineStoreComposable(
     const partitionGroupOptions = computed(() =>
       partitionGroups.value.map(group => ({
         key: group.name,
-        value: group.id
+        value: group.id,
       }))
     )
 
@@ -69,7 +71,7 @@ export const usePartitionGroupStore = defineStoreComposable(
         editedValue.value = {
           name: partitionGroup.name,
           parentPartitionGroupId: partitionGroup.parentPartitionGroupId,
-          depth: partitionGroup.depth
+          depth: partitionGroup.depth,
         }
       } catch {
         throw new Error('パーティショングループの取得に失敗しました')
@@ -104,7 +106,7 @@ export const usePartitionGroupStore = defineStoreComposable(
           name: currentPartitionGroup.value.name,
           parentPartitionGroupId:
             currentPartitionGroup.value.parentPartitionGroupId,
-          depth: currentPartitionGroup.value.depth
+          depth: currentPartitionGroup.value.depth,
         }
         throw new Error('パーティショングループの更新に失敗しました')
       }
@@ -142,7 +144,7 @@ export const usePartitionGroupStore = defineStoreComposable(
       createPartitionGroup,
       editPartitionGroup,
       deletePartitionGroup,
-      resetDetail
+      resetDetail,
     }
   }
 )

--- a/src/features/tag/__mocks__/handlers.ts
+++ b/src/features/tag/__mocks__/handlers.ts
@@ -1,11 +1,12 @@
-import type { Tag } from '@/lib/apis'
 import { HttpResponse, type PathParams, http } from 'msw'
+
+import type { Tag } from '@/lib/apis'
 
 export const mockTag: Tag = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa5',
   name: '2021講習会',
   created_at: '2022-01-25T13:29:19.918Z',
-  updated_at: '2022-01-25T13:29:19.918Z'
+  updated_at: '2022-01-25T13:29:19.918Z',
 }
 
 export const mockTags: Tag[] = [
@@ -13,20 +14,20 @@ export const mockTags: Tag[] = [
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa5',
     name: '2021講習会',
     created_at: '2022-01-25T13:29:19.918Z',
-    updated_at: '2022-01-25T13:29:19.918Z'
+    updated_at: '2022-01-25T13:29:19.918Z',
   },
   {
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     name: '2022講習会',
     created_at: '2022-01-25T13:29:19.918Z',
-    updated_at: '2022-01-25T13:29:19.918Z'
+    updated_at: '2022-01-25T13:29:19.918Z',
   },
   {
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa7',
     name: '2020講習会',
     created_at: '2022-01-25T13:29:19.918Z',
-    updated_at: '2022-01-25T13:29:19.918Z'
-  }
+    updated_at: '2022-01-25T13:29:19.918Z',
+  },
 ]
 
 export const tagHandlers = [
@@ -41,5 +42,5 @@ export const tagHandlers = [
   }),
   http.delete('/api/tags/:id', () => {
     return HttpResponse.json(null)
-  })
+  }),
 ]

--- a/src/features/tag/data/repository.ts
+++ b/src/features/tag/data/repository.ts
@@ -1,12 +1,13 @@
-import type { Tag } from '../entities'
 import apis, { type TagInput } from '@/lib/apis'
+
+import type { Tag } from '../entities'
 
 export const useTagRepository = () => {
   return createTagRepository()
 }
 
 const toTagInput = (name: string): TagInput => ({
-  name
+  name,
 })
 
 const createTagRepository = () => ({
@@ -14,17 +15,17 @@ const createTagRepository = () => ({
     const { data } = await apis.getTags()
     return data.map(tag => ({
       id: tag.id,
-      name: tag.name
+      name: tag.name,
     }))
   },
   createTag: async (name: string): Promise<Tag> => {
     const { data } = await apis.postTag(toTagInput(name))
     return {
       id: data.id,
-      name: data.name
+      name: data.name,
     }
   },
   deleteTag: async (id: string) => {
     await apis.deleteTag(id)
-  }
+  },
 })

--- a/src/features/tag/store.ts
+++ b/src/features/tag/store.ts
@@ -1,8 +1,11 @@
-import type { Tag } from './entities'
-import { TagRepositoryKey } from '@/di'
-import { defineStoreComposable } from '@/lib/store'
-import type { AsyncStatus } from '@/types'
 import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
+import { TagRepositoryKey } from '@/di'
+import type { AsyncStatus } from '@/types'
+
+import type { Tag } from './entities'
 
 export const useTagStore = defineStoreComposable('tag', () => {
   const repository = inject(TagRepositoryKey)
@@ -15,14 +18,14 @@ export const useTagStore = defineStoreComposable('tag', () => {
   const tagOptions = computed(() =>
     tags.value.map(tag => ({
       key: tag.name,
-      value: tag
+      value: tag,
     }))
   )
 
   const tagIdOptions = computed(() =>
     tags.value.map(tag => ({
       key: tag.name,
-      value: tag.id
+      value: tag.id,
     }))
   )
 
@@ -90,7 +93,7 @@ export const useTagStore = defineStoreComposable('tag', () => {
     fetchTags,
     ensureTags,
     deleteTags,
-    reset
+    reset,
   }
 })
 

--- a/src/features/user/__mocks__/handlers.ts
+++ b/src/features/user/__mocks__/handlers.ts
@@ -1,5 +1,6 @@
-import type { User } from '@/lib/apis'
 import { HttpResponse, http } from 'msw'
+
+import type { User } from '@/lib/apis'
 
 export const mockUser: User = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -8,7 +9,7 @@ export const mockUser: User = {
   account_manager: true,
   created_at: '2022-01-27T13:45:37.048Z',
   updated_at: '2022-01-27T13:45:37.048Z',
-  deleted_at: '2022-01-27T13:45:37.048Z'
+  deleted_at: '2022-01-27T13:45:37.048Z',
 }
 
 const mockUsers: User[] = [
@@ -19,7 +20,7 @@ const mockUsers: User[] = [
     account_manager: true,
     created_at: '2022-01-25T13:45:36.048Z',
     updated_at: '2022-01-25T13:45:36.048Z',
-    deleted_at: '2022-01-25T13:45:36.048Z'
+    deleted_at: '2022-01-25T13:45:36.048Z',
   },
   {
     id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
@@ -28,8 +29,8 @@ const mockUsers: User[] = [
     account_manager: true,
     created_at: '2022-01-27T13:45:37.048Z',
     updated_at: '2022-01-27T13:45:37.048Z',
-    deleted_at: '2022-01-27T13:45:37.048Z'
-  }
+    deleted_at: '2022-01-27T13:45:37.048Z',
+  },
 ]
 
 export const userHandlers = [
@@ -40,5 +41,5 @@ export const userHandlers = [
   http.get('/api/users/me', () => {
     const res: User = mockUser
     return HttpResponse.json(res)
-  })
+  }),
 ]

--- a/src/features/user/data/repository.ts
+++ b/src/features/user/data/repository.ts
@@ -1,5 +1,6 @@
-import type { User } from '../entities'
 import apis from '@/lib/apis'
+
+import type { User } from '../entities'
 
 export const useUserRepository = () => {
   return createUserRepository()
@@ -12,7 +13,7 @@ const createUserRepository = () => ({
       id: user.id,
       name: user.name,
       displayName: user.display_name,
-      accountManager: user.account_manager
+      accountManager: user.account_manager,
     }))
   },
   fetchMe: async (): Promise<User> => {
@@ -21,7 +22,7 @@ const createUserRepository = () => ({
       id: data.id,
       name: data.name,
       displayName: data.display_name,
-      accountManager: data.account_manager
+      accountManager: data.account_manager,
     }
-  }
+  },
 })

--- a/src/features/user/store.ts
+++ b/src/features/user/store.ts
@@ -1,8 +1,11 @@
-import type { User } from './entities'
-import { UserRepositoryKey } from '@/di'
-import { defineStoreComposable } from '@/lib/store'
-import type { AsyncStatus } from '@/types'
 import { computed, inject, ref } from 'vue'
+
+import { defineStoreComposable } from '@/lib/store'
+
+import { UserRepositoryKey } from '@/di'
+import type { AsyncStatus } from '@/types'
+
+import type { User } from './entities'
 
 export const useUserStore = defineStoreComposable('user', () => {
   const repository = inject(UserRepositoryKey)
@@ -18,7 +21,7 @@ export const useUserStore = defineStoreComposable('user', () => {
   const userOptions = computed(() =>
     users.value.map(user => ({
       key: user.name,
-      value: user.id
+      value: user.id,
     }))
   )
   const userMap = computed(() =>
@@ -83,7 +86,7 @@ export const useUserStore = defineStoreComposable('user', () => {
     getUserNameWithFallback,
     fetchUsers,
     fetchMe,
-    reset
+    reset,
   }
 })
 

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -2,7 +2,7 @@ import { Apis, Configuration } from './generated'
 
 export default new Apis(
   new Configuration({
-    basePath: '/api'
+    basePath: '/api',
   })
 )
 

--- a/src/lib/msw.ts
+++ b/src/lib/msw.ts
@@ -13,5 +13,5 @@ export const handlers = [
   accountManagerHandlers,
   tagHandlers,
   userHandlers,
-  fileHandlers
+  fileHandlers,
 ].flat()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,21 @@
+import { Fragment, createApp, h } from 'vue'
+
+import { createPinia } from 'pinia'
+
+import { setupWorker } from 'msw/browser'
+import Toast, { POSITION } from 'vue-toastification'
+import type { PluginOptions } from 'vue-toastification'
+import 'vue-toastification/dist/index.css'
+
+import { handlers } from '@/lib/msw'
+
+import { useAccountManagerRepository } from '@/features/accountManager/data/repository'
+import { useApplicationRepository } from '@/features/application/data/repository'
+import { usePartitionRepository } from '@/features/partition/data/repository'
+import { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
+import { useTagRepository } from '@/features/tag/data/repository'
+import { useUserRepository } from '@/features/user/data/repository'
+
 import App from './App.vue'
 import {
   AccountManagerRepositoryKey,
@@ -5,22 +23,9 @@ import {
   PartitionGroupRepositoryKey,
   PartitionRepositoryKey,
   TagRepositoryKey,
-  UserRepositoryKey
+  UserRepositoryKey,
 } from './di'
 import router from './router'
-import { useAccountManagerRepository } from '@/features/accountManager/data/repository'
-import { useApplicationRepository } from '@/features/application/data/repository'
-import { usePartitionRepository } from '@/features/partition/data/repository'
-import { usePartitionGroupRepository } from '@/features/partitionGroup/data/repository'
-import { useTagRepository } from '@/features/tag/data/repository'
-import { useUserRepository } from '@/features/user/data/repository'
-import { handlers } from '@/lib/msw'
-import { setupWorker } from 'msw/browser'
-import { createPinia } from 'pinia'
-import { Fragment, createApp, h } from 'vue'
-import type { PluginOptions } from 'vue-toastification'
-import Toast, { POSITION } from 'vue-toastification'
-import 'vue-toastification/dist/index.css'
 
 if (
   import.meta.env.MODE === 'development' &&
@@ -28,7 +33,7 @@ if (
 ) {
   const worker = setupWorker(...handlers)
   await worker.start({
-    onUnhandledRequest: 'bypass'
+    onUnhandledRequest: 'bypass',
   })
 }
 
@@ -40,7 +45,7 @@ const setup = async () => {
   // NOTE: 開発環境では vue-axe を読み込む
   const VueAxe = await import('vue-axe')
   const app = createApp({
-    render: () => h(Fragment, [h(App), h(VueAxe.VueAxePopup)])
+    render: () => h(Fragment, [h(App), h(VueAxe.VueAxePopup)]),
   })
   app.use(VueAxe.default)
 
@@ -53,7 +58,7 @@ const options: PluginOptions = {
   timeout: 3000,
   closeButton: false,
   pauseOnHover: false,
-  hideProgressBar: true
+  hideProgressBar: true,
 }
 
 await setup().then(app => {

--- a/src/pages/AccountManagerPage.vue
+++ b/src/pages/AccountManagerPage.vue
@@ -1,25 +1,28 @@
 <script lang="ts" setup>
-import { useAccountManager } from './composables/useAccountManager'
+import { ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import SearchSelect from '@/components/shared/SearchSelect.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
 import { useAccountManagerStore } from '@/features/accountManager/store'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { ref } from 'vue'
-import { useToast } from 'vue-toastification'
+
+import { useAccountManager } from './composables/useAccountManager'
 
 const {
   isAccountManagerFetched,
   accountManagers,
   accountManagerOptions,
-  fetchAccountManagers
+  fetchAccountManagers,
 } = useAccountManagerStore()
 const {
   me,
   isUserFetched,
   isAccountManager,
   getUserNameWithFallback,
-  fetchUsers
+  fetchUsers,
 } = useUserStore()
 const { isTagFetched, tagIdOptions, deleteTags, fetchTags } = useTagStore()
 const toast = useToast()

--- a/src/pages/ApplicationDetailPage.vue
+++ b/src/pages/ApplicationDetailPage.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
+import { toId } from '@/lib/parseQueryParams'
+
 import ApplicationHeader from '@/components/applicationDetail/ApplicationHeader.vue'
 import ApplicationLogs from '@/components/applicationDetail/ApplicationLogs.vue'
 import ApplicationSidebar from '@/components/applicationDetail/ApplicationSidebar.vue'
@@ -6,8 +10,6 @@ import { useApplicationStore } from '@/features/application/store'
 import { usePartitionStore } from '@/features/partition/store'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { toId } from '@/lib/parseQueryParams'
-import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const id = toId(route.params.id)

--- a/src/pages/ApplicationsPage.vue
+++ b/src/pages/ApplicationsPage.vue
@@ -1,4 +1,12 @@
 <script lang="ts" setup>
+import { ref, watch } from 'vue'
+
+import { RouterLink, useRoute } from 'vue-router'
+
+import { useToast } from 'vue-toastification'
+
+import { toPage } from '@/lib/parseQueryParams'
+
 import ApplicationItem from '@/components/applications/ApplicationItem.vue'
 import PaginationBar from '@/components/shared/PaginationBar.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
@@ -6,10 +14,6 @@ import { useApplicationStore } from '@/features/application/store'
 import { usePartitionStore } from '@/features/partition/store'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { toPage } from '@/lib/parseQueryParams'
-import { ref, watch } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
-import { useToast } from 'vue-toastification'
 
 const route = useRoute()
 const page = ref(toPage(route.query.page))

--- a/src/pages/NewApplicationPage.vue
+++ b/src/pages/NewApplicationPage.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { useNewApplication } from './composables/useNewApplication'
+import { useToast } from 'vue-toastification'
+
 import NewApplicationFileForm from '@/components/newApplication/NewApplicationFileForm.vue'
 import NewApplicationTargets from '@/components/newApplication/NewApplicationTargets.vue'
 import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
@@ -11,7 +12,8 @@ import { applicationTemplates } from '@/features/applicationTemplate/entities'
 import { usePartitionStore } from '@/features/partition/store'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { useToast } from 'vue-toastification'
+
+import { useNewApplication } from './composables/useNewApplication'
 
 const { isTagFetched, fetchTags } = useTagStore()
 const { isUserFetched, fetchUsers, me } = useUserStore()

--- a/src/pages/NewPartitionPage.vue
+++ b/src/pages/NewPartitionPage.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
-import { useNewPartition } from './composables/useNewPartition'
+import { ref, watch } from 'vue'
+
 import BaseNumberInput from '@/components/shared/BaseInput/BaseNumberInput.vue'
 import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
 import InputCheckBox from '@/components/shared/InputCheckBox.vue'
@@ -7,7 +8,8 @@ import SearchSelect from '@/components/shared/SearchSelect.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
 import { usePartitionGroupStore } from '@/features/partitionGroup/store'
 import { useUserStore } from '@/features/user/store'
-import { ref, watch } from 'vue'
+
+import { useNewPartition } from './composables/useNewPartition'
 
 const { partitionGroupOptions, isPartitionGroupFetched, fetchPartitionGroups } =
   usePartitionGroupStore()

--- a/src/pages/PartitionDetailPage.vue
+++ b/src/pages/PartitionDetailPage.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+import { useRoute } from 'vue-router'
+
+import { toId } from '@/lib/parsePathParams'
+
 import PartitionBudget from '@/components/partitionDetail/PartitionBudget.vue'
 import PartitionGroup from '@/components/partitionDetail/PartitionGroup.vue'
 import PartitionName from '@/components/partitionDetail/PartitionName.vue'
@@ -6,8 +10,6 @@ import { usePartitionInformation } from '@/components/partitionDetail/composable
 import { usePartitionStore } from '@/features/partition/store'
 import { usePartitionGroupStore } from '@/features/partitionGroup/store'
 import { useUserStore } from '@/features/user/store'
-import { toId } from '@/lib/parsePathParams'
-import { useRoute } from 'vue-router'
 
 const route = useRoute()
 const id = toId(route.params.id)

--- a/src/pages/PartitionsPage.vue
+++ b/src/pages/PartitionsPage.vue
@@ -1,13 +1,16 @@
 <script lang="ts" setup>
+import { ref, watch } from 'vue'
+
+import { RouterLink, useRoute } from 'vue-router'
+
+import { toPage } from '@/lib/parseQueryParams'
+
 import PartitionTable from '@/components/partitions/PartitionTable.vue'
 import PaginationBar from '@/components/shared/PaginationBar.vue'
 import SimpleButton from '@/components/shared/SimpleButton.vue'
 import { usePartitionStore } from '@/features/partition/store'
 import { usePartitionGroupStore } from '@/features/partitionGroup/store'
 import { useUserStore } from '@/features/user/store'
-import { toPage } from '@/lib/parseQueryParams'
-import { ref, watch } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
 
 const route = useRoute()
 const page = ref(toPage(route.query.page))

--- a/src/pages/composables/useAccountManager.ts
+++ b/src/pages/composables/useAccountManager.ts
@@ -1,7 +1,9 @@
+import { computed, ref } from 'vue'
+
+import { useToast } from 'vue-toastification'
+
 import { useAccountManagerStore } from '@/features/accountManager/store'
 import { useUserStore } from '@/features/user/store'
-import { computed, ref } from 'vue'
-import { useToast } from 'vue-toastification'
 
 export const useAccountManager = () => {
   const { users } = useUserStore()
@@ -14,7 +16,7 @@ export const useAccountManager = () => {
       .filter(user => !accountManagers.value.includes(user.id))
       .map(user => ({
         key: user.name,
-        value: user.id
+        value: user.id,
       }))
   })
 
@@ -71,6 +73,6 @@ export const useAccountManager = () => {
     absentMembers,
     isSending,
     addAccountManagers: addAccountManagersHandler,
-    removeAccountManagers: removeAccountManagersHandler
+    removeAccountManagers: removeAccountManagersHandler,
   }
 }

--- a/src/pages/composables/useNewApplication.ts
+++ b/src/pages/composables/useNewApplication.ts
@@ -1,17 +1,20 @@
+import { ref } from 'vue'
+
+import { useRouter } from 'vue-router'
+
+import { useToast } from 'vue-toastification'
+
 import type { ApplicationSeed } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import type {
   ApplicationTarget,
-  ApplicationTargetDraft
+  ApplicationTargetDraft,
 } from '@/features/applicationTarget/entities'
 import type { FileSeed } from '@/features/file/entities'
 import { createFiles } from '@/features/file/services'
 import type { Tag } from '@/features/tag/entities'
 import { useTagStore } from '@/features/tag/store'
 import { useUserStore } from '@/features/user/store'
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { useToast } from 'vue-toastification'
 
 export const useNewApplication = () => {
   const toast = useToast()
@@ -40,7 +43,7 @@ export const useNewApplication = () => {
     targets: [{ target: '', amount: null }],
     content: '',
     tags: [],
-    partition: ''
+    partition: '',
   })
   const files = ref<FileSeed[]>([])
 
@@ -84,7 +87,7 @@ export const useNewApplication = () => {
         content: application.value.content,
         tags,
         partition: application.value.partition,
-        targets
+        targets,
       }
       const res = await createApplication(applicationSeedWithNewTags)
       try {

--- a/src/pages/composables/useNewPartition.ts
+++ b/src/pages/composables/useNewPartition.ts
@@ -1,8 +1,11 @@
+import { ref } from 'vue'
+
+import { useRouter } from 'vue-router'
+
+import { useToast } from 'vue-toastification'
+
 import type { PartitionSeed } from '@/features/partition/entities'
 import { usePartitionStore } from '@/features/partition/store'
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { useToast } from 'vue-toastification'
 
 export const useNewPartition = () => {
   const isSending = ref(false)
@@ -15,8 +18,8 @@ export const useNewPartition = () => {
     parentPartitionGroupId: '',
     management: {
       category: 'manual',
-      state: 'available'
-    }
+      state: 'available',
+    },
   })
   const handleCreatePartition = async () => {
     if (partition.value.name === '') {

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,42 +1,42 @@
-import type { RouteRecordRaw } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
+import type { RouteRecordRaw } from 'vue-router'
 
 const routes: RouteRecordRaw[] = [
   { path: '/', redirect: '/applications' },
   {
     path: '/applications',
-    component: () => import('./pages/ApplicationsPage.vue')
+    component: () => import('./pages/ApplicationsPage.vue'),
   },
   {
     path: '/applications/new',
-    component: () => import('./pages/NewApplicationPage.vue')
+    component: () => import('./pages/NewApplicationPage.vue'),
   },
   {
     path: '/applications/:id',
-    component: () => import('./pages/ApplicationDetailPage.vue')
+    component: () => import('./pages/ApplicationDetailPage.vue'),
   },
   {
     path: '/partitions',
-    component: () => import('./pages/PartitionsPage.vue')
+    component: () => import('./pages/PartitionsPage.vue'),
   },
   {
     path: '/partitions/new',
-    component: () => import('./pages/NewPartitionPage.vue')
+    component: () => import('./pages/NewPartitionPage.vue'),
   },
   {
     path: '/partitions/:id',
-    component: () => import('./pages/PartitionDetailPage.vue')
+    component: () => import('./pages/PartitionDetailPage.vue'),
   },
   {
     path: '/account-managers',
-    component: () => import('./pages/AccountManagerPage.vue')
+    component: () => import('./pages/AccountManagerPage.vue'),
   },
-  { path: '/:path(.*)', component: () => import('./pages/NotFoundPage.vue') }
+  { path: '/:path(.*)', component: () => import('./pages/NotFoundPage.vue') },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
-  routes
+  routes,
 })
 
 export default router

--- a/tests/BaseInput/BaseInputFrame.spec.ts
+++ b/tests/BaseInput/BaseInputFrame.spec.ts
@@ -1,20 +1,22 @@
-import BaseInputFrame from '@/components/shared/BaseInput/BaseInputFrame.vue'
+import { nextTick } from 'vue'
+
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+
+import BaseInputFrame from '@/components/shared/BaseInput/BaseInputFrame.vue'
 
 describe('BaseInputFrame', () => {
   const baseProps = {
     label: 'ラベル',
-    inputId: 'field-id'
+    inputId: 'field-id',
   }
 
   it('label を表示し、for 属性で inputId と関連付ける', () => {
     const wrapper = mount(BaseInputFrame, {
       props: baseProps,
       slots: {
-        default: '<input />'
-      }
+        default: '<input />',
+      },
     })
 
     const label = wrapper.get('label')
@@ -26,7 +28,7 @@ describe('BaseInputFrame', () => {
   it('required かつ readonly/disabled でないときだけ * を表示する', async () => {
     const wrapper = mount(BaseInputFrame, {
       props: { ...baseProps, required: true },
-      slots: { default: '<input />' }
+      slots: { default: '<input />' },
     })
 
     // required=true
@@ -46,7 +48,7 @@ describe('BaseInputFrame', () => {
   it('hasValue に応じてラベルの位置クラスを切り替える', async () => {
     const wrapper = mount(BaseInputFrame, {
       props: { ...baseProps, hasValue: false },
-      slots: { default: '<input />' }
+      slots: { default: '<input />' },
     })
 
     const label = wrapper.get('label')
@@ -64,7 +66,7 @@ describe('BaseInputFrame', () => {
   it('focusin/out でフォーカス状態に応じてラベル位置を切り替える', async () => {
     const wrapper = mount(BaseInputFrame, {
       props: { ...baseProps, hasValue: false },
-      slots: { default: '<input />' }
+      slots: { default: '<input />' },
     })
 
     const label = wrapper.get('label')
@@ -86,7 +88,7 @@ describe('BaseInputFrame', () => {
   it('isTextarea=true かつ hasValue=false のとき textarea 用の位置クラスを使う', () => {
     const wrapper = mount(BaseInputFrame, {
       props: { ...baseProps, isTextarea: true, hasValue: false },
-      slots: { default: '<textarea />' }
+      slots: { default: '<textarea />' },
     })
 
     const label = wrapper.get('label')
@@ -99,9 +101,9 @@ describe('BaseInputFrame', () => {
       props: {
         ...baseProps,
         errorMessage: 'エラーです',
-        errorMessageId: 'field-id-error'
+        errorMessageId: 'field-id-error',
       },
-      slots: { default: '<input />' }
+      slots: { default: '<input />' },
     })
 
     const error = wrapper.get('[role="alert"]')
@@ -117,8 +119,8 @@ describe('BaseInputFrame', () => {
       props: baseProps,
       slots: {
         prefix: '<span class="prefix">P</span>',
-        default: '<input />'
-      }
+        default: '<input />',
+      },
     })
 
     expect(wrapper.find('.prefix').exists()).toBe(true)

--- a/tests/BaseInput/BaseNumberInput.spec.ts
+++ b/tests/BaseInput/BaseNumberInput.spec.ts
@@ -1,7 +1,9 @@
-import BaseNumberInput from '@/components/shared/BaseInput/BaseNumberInput.vue'
+import { nextTick } from 'vue'
+
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+
+import BaseNumberInput from '@/components/shared/BaseInput/BaseNumberInput.vue'
 
 describe('BaseNumberInput', () => {
   it('number input として min/max/step/inputmode を反映する', () => {
@@ -15,8 +17,8 @@ describe('BaseNumberInput', () => {
         inputmode: 'numeric',
         required: true,
         errorMessage: 'エラーです',
-        describedById: 'helper-id'
-      }
+        describedById: 'helper-id',
+      },
     })
 
     const input = wrapper.get('input')
@@ -47,8 +49,8 @@ describe('BaseNumberInput', () => {
         label: '数量',
         modelValue: null,
         required: true,
-        readonly: true
-      }
+        readonly: true,
+      },
     })
 
     const input = wrapper.get('input')
@@ -67,8 +69,8 @@ describe('BaseNumberInput', () => {
     const wrapper = mount(BaseNumberInput, {
       props: {
         label: '数量',
-        modelValue: null
-      }
+        modelValue: null,
+      },
     })
 
     const input = wrapper.get('input')
@@ -84,8 +86,8 @@ describe('BaseNumberInput', () => {
     const wrapper = mount(BaseNumberInput, {
       props: {
         label: '数量',
-        modelValue: null
-      }
+        modelValue: null,
+      },
     })
 
     const input = wrapper.get('input')
@@ -103,8 +105,8 @@ describe('BaseNumberInput', () => {
     const wrapper = mount(BaseNumberInput, {
       props: {
         label: '数量',
-        modelValue: 10
-      }
+        modelValue: 10,
+      },
     })
 
     const input = wrapper.get('input')
@@ -121,8 +123,8 @@ describe('BaseNumberInput', () => {
     const wrapper = mount(BaseNumberInput, {
       props: {
         label: '数量',
-        modelValue: null
-      }
+        modelValue: null,
+      },
     })
 
     const input = wrapper.get('input')

--- a/tests/BaseInput/BaseTextInput.spec.ts
+++ b/tests/BaseInput/BaseTextInput.spec.ts
@@ -1,6 +1,7 @@
-import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+
+import BaseTextInput from '@/components/shared/BaseInput/BaseTextInput.vue'
 
 describe('BaseTextInput', () => {
   it('デフォルトでは input[type=text] を描画し、基本的な ARIA を設定する', () => {
@@ -10,8 +11,8 @@ describe('BaseTextInput', () => {
         modelValue: '',
         required: true,
         errorMessage: 'エラーです',
-        describedById: 'helper-id'
-      }
+        describedById: 'helper-id',
+      },
     })
 
     const input = wrapper.get('input')
@@ -40,8 +41,8 @@ describe('BaseTextInput', () => {
         modelValue: '',
         type: 'email',
         inputmode: 'email',
-        autocomplete: 'email'
-      }
+        autocomplete: 'email',
+      },
     })
 
     const input = wrapper.get('input')
@@ -57,8 +58,8 @@ describe('BaseTextInput', () => {
         label: 'メモ',
         modelValue: '',
         textarea: true,
-        rows: 4
-      }
+        rows: 4,
+      },
     })
 
     expect(wrapper.find('textarea').exists()).toBe(true)
@@ -73,8 +74,8 @@ describe('BaseTextInput', () => {
     const wrapper = mount(BaseTextInput, {
       props: {
         label: '名前',
-        modelValue: 'initial'
-      }
+        modelValue: 'initial',
+      },
     })
 
     const input = wrapper.get('input')
@@ -93,8 +94,8 @@ describe('BaseTextInput', () => {
     const wrapper = mount(BaseTextInput, {
       props: {
         label: '名前',
-        modelValue: ''
-      }
+        modelValue: '',
+      },
     })
 
     const input = wrapper.get('input')

--- a/tests/BaseInput/useBaseInput.spec.ts
+++ b/tests/BaseInput/useBaseInput.spec.ts
@@ -1,7 +1,9 @@
-import { useBaseInput } from '@/components/shared/BaseInput/useBaseInput'
+import { defineComponent } from 'vue'
+
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
-import { defineComponent } from 'vue'
+
+import { useBaseInput } from '@/components/shared/BaseInput/useBaseInput'
 
 const TestComponent = defineComponent({
   props: {
@@ -10,19 +12,19 @@ const TestComponent = defineComponent({
     readonly: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
     errorMessage: { type: String, default: '' },
-    describedById: { type: String, default: '' }
+    describedById: { type: String, default: '' },
   },
   setup(props) {
     const state = useBaseInput(props)
     return state
   },
-  template: '<div />'
+  template: '<div />',
 })
 
 describe('useBaseInput', () => {
   it('id が指定されていればそのまま inputId に使う', () => {
     const wrapper = mount(TestComponent, {
-      props: { id: 'custom-id' }
+      props: { id: 'custom-id' },
     })
 
     expect(wrapper.vm.inputId).toBe('custom-id')
@@ -36,7 +38,7 @@ describe('useBaseInput', () => {
 
   it('required かつ readonly/disabled でないときだけ isFieldRequired が true になる', async () => {
     const wrapper = mount(TestComponent, {
-      props: { required: true }
+      props: { required: true },
     })
 
     expect(wrapper.vm.isFieldRequired).toBe(true)
@@ -60,7 +62,7 @@ describe('useBaseInput', () => {
 
   it('describedById と errorMessageId を aria-describedby 用に連結する', async () => {
     const wrapper = mount(TestComponent, {
-      props: { describedById: 'helper-id' }
+      props: { describedById: 'helper-id' },
     })
 
     // errorMessage がないので helper-id のみ
@@ -79,14 +81,14 @@ describe('useBaseInput', () => {
 
     await wrapper.setProps({
       describedById: undefined,
-      errorMessage: undefined
+      errorMessage: undefined,
     })
     expect(wrapper.vm.describedBy).toBeUndefined()
   })
 
   it('describedById がなくても errorMessage があれば errorMessageId のみを返す', () => {
     const wrapper = mount(TestComponent, {
-      props: { errorMessage: 'エラーです' }
+      props: { errorMessage: 'エラーです' },
     })
 
     const errorId = wrapper.vm.errorMessageId

--- a/tests/features/accountManager/store.spec.ts
+++ b/tests/features/accountManager/store.spec.ts
@@ -1,13 +1,16 @@
+import { computed, createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { AccountManagerRepositoryKey } from '@/di'
 import { useAccountManagerStore } from '@/features/accountManager/store'
 import { useUserStore } from '@/features/user/store'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed, createApp } from 'vue'
 
 // Mock user store
 vi.mock('@/features/user/store', () => ({
-  useUserStore: vi.fn()
+  useUserStore: vi.fn(),
 }))
 
 describe('AccountManager Store', () => {
@@ -24,7 +27,7 @@ describe('AccountManager Store', () => {
     vi.mocked(useUserStore).mockReturnValue({
       userMap: computed(() => ({})),
       getUserName: () => undefined,
-      getUserNameWithFallback: () => '不明なユーザー'
+      getUserNameWithFallback: () => '不明なユーザー',
     } as unknown as ReturnType<typeof useUserStore>)
   })
 
@@ -33,7 +36,7 @@ describe('AccountManager Store', () => {
   const createMockRepository = () => ({
     fetchAccountManagers: vi.fn(),
     addAccountManagers: vi.fn(),
-    removeAccountManagers: vi.fn()
+    removeAccountManagers: vi.fn(),
   })
 
   describe('actions', () => {
@@ -43,7 +46,7 @@ describe('AccountManager Store', () => {
         .mockResolvedValue(mockAccountManagers)
       const mockRepo = {
         ...createMockRepository(),
-        fetchAccountManagers: mockFetchAccountManagers
+        fetchAccountManagers: mockFetchAccountManagers,
       }
       app.provide(AccountManagerRepositoryKey, mockRepo)
 
@@ -62,7 +65,7 @@ describe('AccountManager Store', () => {
         .mockRejectedValue(new Error('Network error'))
       const mockRepo = {
         ...createMockRepository(),
-        fetchAccountManagers: mockFetchAccountManagers
+        fetchAccountManagers: mockFetchAccountManagers,
       }
       app.provide(AccountManagerRepositoryKey, mockRepo)
 
@@ -78,7 +81,7 @@ describe('AccountManager Store', () => {
       const mockAddAccountManagers = vi.fn().mockResolvedValue(undefined)
       const mockRepo = {
         ...createMockRepository(),
-        addAccountManagers: mockAddAccountManagers
+        addAccountManagers: mockAddAccountManagers,
       }
       app.provide(AccountManagerRepositoryKey, mockRepo)
 
@@ -95,7 +98,7 @@ describe('AccountManager Store', () => {
       const mockRemoveAccountManagers = vi.fn().mockResolvedValue(undefined)
       const mockRepo = {
         ...createMockRepository(),
-        removeAccountManagers: mockRemoveAccountManagers
+        removeAccountManagers: mockRemoveAccountManagers,
       }
       app.provide(AccountManagerRepositoryKey, mockRepo)
 
@@ -113,14 +116,14 @@ describe('AccountManager Store', () => {
     it('accountManagerOptions returns formatted options', () => {
       const mockUserMap: Record<string, string> = {
         'user-1': 'User 1',
-        'user-2': 'User 2'
+        'user-2': 'User 2',
       }
 
       vi.mocked(useUserStore).mockReturnValue({
         userMap: computed(() => mockUserMap),
         getUserName: (id: string) => mockUserMap[id],
         getUserNameWithFallback: (id: string) =>
-          mockUserMap[id] ?? '不明なユーザー'
+          mockUserMap[id] ?? '不明なユーザー',
       } as unknown as ReturnType<typeof useUserStore>)
 
       app.provide(AccountManagerRepositoryKey, createMockRepository())
@@ -129,7 +132,7 @@ describe('AccountManager Store', () => {
 
       expect(store.accountManagerOptions.value).toEqual([
         { key: 'User 1', value: 'user-1' },
-        { key: 'User 2', value: 'user-2' }
+        { key: 'User 2', value: 'user-2' },
       ])
     })
   })

--- a/tests/features/application/store.spec.ts
+++ b/tests/features/application/store.spec.ts
@@ -1,21 +1,24 @@
+import { createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { DateTime } from 'luxon'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { ApplicationRepositoryKey } from '@/di'
 import type {
   Application,
   ApplicationDetail,
-  ApplicationSeed
+  ApplicationSeed,
 } from '@/features/application/entities'
 import { useApplicationStore } from '@/features/application/store'
 import type { ApplicationComment } from '@/features/applicationComment/entities'
 import type { ApplicationStatusDetail } from '@/features/applicationStatus/entities'
 import { useTagStore } from '@/features/tag/store'
-import { DateTime } from 'luxon'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
 
 // Mock tag store
 vi.mock('@/features/tag/store', () => ({
-  useTagStore: vi.fn()
+  useTagStore: vi.fn(),
 }))
 
 describe('Application Store', () => {
@@ -44,17 +47,17 @@ describe('Application Store', () => {
       parentPartitionGroupId: 'group-1',
       management: { category: 'manual', state: 'available' },
       createdAt: '2023-01-01T00:00:00Z',
-      updatedAt: '2023-01-01T00:00:00Z'
+      updatedAt: '2023-01-01T00:00:00Z',
     },
     createdAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
-    updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+    updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
   }
 
   const mockApplicationDetail: ApplicationDetail = {
     ...mockApplication,
     files: [],
     comments: [],
-    statuses: []
+    statuses: [],
   }
 
   const mockSeed: ApplicationSeed = {
@@ -63,7 +66,7 @@ describe('Application Store', () => {
     content: 'New Content',
     tags: [],
     partition: 'part-1',
-    targets: []
+    targets: [],
   }
 
   const createMockRepository = () => ({
@@ -72,7 +75,7 @@ describe('Application Store', () => {
     createApplication: vi.fn(),
     editApplication: vi.fn(),
     createComment: vi.fn(),
-    editStatus: vi.fn()
+    editStatus: vi.fn(),
   })
 
   describe('actions', () => {
@@ -80,7 +83,7 @@ describe('Application Store', () => {
       const mockFetchApplications = vi.fn().mockResolvedValue([mockApplication])
       const mockRepo = {
         ...createMockRepository(),
-        fetchApplications: mockFetchApplications
+        fetchApplications: mockFetchApplications,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
@@ -99,7 +102,7 @@ describe('Application Store', () => {
         .mockRejectedValue(new Error('Network error'))
       const mockRepo = {
         ...createMockRepository(),
-        fetchApplications: mockFetchApplications
+        fetchApplications: mockFetchApplications,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
@@ -117,7 +120,7 @@ describe('Application Store', () => {
         .mockResolvedValue(mockApplicationDetail)
       const mockRepo = {
         ...createMockRepository(),
-        fetchApplication: mockFetchApplication
+        fetchApplication: mockFetchApplication,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
@@ -134,7 +137,7 @@ describe('Application Store', () => {
         .mockResolvedValue(mockApplicationDetail)
       const mockRepo = {
         ...createMockRepository(),
-        createApplication: mockCreateApplication
+        createApplication: mockCreateApplication,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
@@ -148,17 +151,17 @@ describe('Application Store', () => {
     it('editApplication updates application and list', async () => {
       const mockUpdatedApp: ApplicationDetail = {
         ...mockApplicationDetail,
-        title: 'Updated Title'
+        title: 'Updated Title',
       }
       const mockEditApplication = vi.fn().mockResolvedValue(mockUpdatedApp)
       const mockRepo = {
         ...createMockRepository(),
-        editApplication: mockEditApplication
+        editApplication: mockEditApplication,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
       vi.mocked(useTagStore).mockReturnValue({
-        ensureTags: vi.fn().mockResolvedValue([])
+        ensureTags: vi.fn().mockResolvedValue([]),
       } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 
       const store = app.runWithContext(() => useApplicationStore())
@@ -178,12 +181,12 @@ describe('Application Store', () => {
         comment: 'Test Comment',
         user: 'user-1',
         createdAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
-        updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+        updatedAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
       }
       const mockCreateComment = vi.fn().mockResolvedValue(mockComment)
       const mockRepo = {
         ...createMockRepository(),
-        createComment: mockCreateComment
+        createComment: mockCreateComment,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 
@@ -202,12 +205,12 @@ describe('Application Store', () => {
       const mockStatusDetail: ApplicationStatusDetail = {
         status: 'approved',
         createdBy: 'user-1',
-        createdAt: DateTime.fromISO('2023-01-01T00:00:00Z')
+        createdAt: DateTime.fromISO('2023-01-01T00:00:00Z'),
       }
       const mockEditStatus = vi.fn().mockResolvedValue(mockStatusDetail)
       const mockRepo = {
         ...createMockRepository(),
-        editStatus: mockEditStatus
+        editStatus: mockEditStatus,
       }
       app.provide(ApplicationRepositoryKey, mockRepo)
 

--- a/tests/features/partition/store.spec.ts
+++ b/tests/features/partition/store.spec.ts
@@ -1,9 +1,12 @@
+import { createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { PartitionRepositoryKey } from '@/di'
 import type { Partition, PartitionSeed } from '@/features/partition/entities'
 import { usePartitionStore } from '@/features/partition/store'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
 
 describe('Partition Store', () => {
   let app: ReturnType<typeof createApp>
@@ -23,10 +26,10 @@ describe('Partition Store', () => {
     parentPartitionGroupId: 'group-1',
     management: {
       category: 'manual',
-      state: 'available'
+      state: 'available',
     },
     createdAt: '2023-01-01T00:00:00Z',
-    updatedAt: '2023-01-01T00:00:00Z'
+    updatedAt: '2023-01-01T00:00:00Z',
   }
 
   const mockSeed: PartitionSeed = {
@@ -35,8 +38,8 @@ describe('Partition Store', () => {
     parentPartitionGroupId: 'group-1',
     management: {
       category: 'manual',
-      state: 'available'
-    }
+      state: 'available',
+    },
   }
 
   const createMockRepository = () => ({
@@ -44,7 +47,7 @@ describe('Partition Store', () => {
     fetchPartition: vi.fn(),
     createPartition: vi.fn(),
     editPartition: vi.fn(),
-    deletePartition: vi.fn()
+    deletePartition: vi.fn(),
   })
 
   describe('actions', () => {
@@ -52,7 +55,7 @@ describe('Partition Store', () => {
       const mockFetchPartitions = vi.fn().mockResolvedValue([mockPartition])
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartitions: mockFetchPartitions
+        fetchPartitions: mockFetchPartitions,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -71,7 +74,7 @@ describe('Partition Store', () => {
         .mockRejectedValue(new Error('Network error'))
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartitions: mockFetchPartitions
+        fetchPartitions: mockFetchPartitions,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -89,7 +92,7 @@ describe('Partition Store', () => {
       const mockFetchPartition = vi.fn().mockResolvedValue(mockPartition)
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartition: mockFetchPartition
+        fetchPartition: mockFetchPartition,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -102,7 +105,7 @@ describe('Partition Store', () => {
         name: mockPartition.name,
         budget: mockPartition.budget,
         parentPartitionGroupId: mockPartition.parentPartitionGroupId,
-        management: mockPartition.management
+        management: mockPartition.management,
       })
     })
 
@@ -110,7 +113,7 @@ describe('Partition Store', () => {
       const mockCreatePartition = vi.fn().mockResolvedValue(mockPartition)
       const mockRepo = {
         ...createMockRepository(),
-        createPartition: mockCreatePartition
+        createPartition: mockCreatePartition,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -124,12 +127,12 @@ describe('Partition Store', () => {
     it('editPartition updates partition and list', async () => {
       const mockUpdatedPartition: Partition = {
         ...mockPartition,
-        name: 'Updated Partition'
+        name: 'Updated Partition',
       }
       const mockEditPartition = vi.fn().mockResolvedValue(mockUpdatedPartition)
       const mockRepo = {
         ...createMockRepository(),
-        editPartition: mockEditPartition
+        editPartition: mockEditPartition,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -148,7 +151,7 @@ describe('Partition Store', () => {
       const mockDeletePartition = vi.fn().mockResolvedValue(undefined)
       const mockRepo = {
         ...createMockRepository(),
-        deletePartition: mockDeletePartition
+        deletePartition: mockDeletePartition,
       }
       app.provide(PartitionRepositoryKey, mockRepo)
 
@@ -169,7 +172,7 @@ describe('Partition Store', () => {
       store.partitions.value = [mockPartition]
 
       expect(store.partitionOptions.value).toEqual([
-        { key: mockPartition.name, value: mockPartition.id }
+        { key: mockPartition.name, value: mockPartition.id },
       ])
     })
   })

--- a/tests/features/partitionGroup/store.spec.ts
+++ b/tests/features/partitionGroup/store.spec.ts
@@ -1,13 +1,16 @@
+import { createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { PartitionGroupRepositoryKey } from '@/di'
 import type {
   PartitionGroup,
-  PartitionGroupSeed
+  PartitionGroupSeed,
 } from '@/features/partitionGroup/entities'
 import { usePartitionGroupStore } from '@/features/partitionGroup/store'
 import type { User } from '@/features/user/entities'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
 
 describe('PartitionGroup Store', () => {
   let app: ReturnType<typeof createApp>
@@ -26,13 +29,13 @@ describe('PartitionGroup Store', () => {
     parentPartitionGroupId: null,
     depth: 0,
     createdAt: '2023-01-01T00:00:00Z',
-    updatedAt: '2023-01-01T00:00:00Z'
+    updatedAt: '2023-01-01T00:00:00Z',
   }
 
   const mockSeed: PartitionGroupSeed = {
     name: 'New Group',
     parentPartitionGroupId: null,
-    depth: 0
+    depth: 0,
   }
 
   const createMockRepository = () => ({
@@ -40,7 +43,7 @@ describe('PartitionGroup Store', () => {
     fetchPartitionGroup: vi.fn(),
     createPartitionGroup: vi.fn(),
     editPartitionGroup: vi.fn(),
-    deletePartitionGroup: vi.fn()
+    deletePartitionGroup: vi.fn(),
   })
 
   describe('actions', () => {
@@ -50,7 +53,7 @@ describe('PartitionGroup Store', () => {
         .mockResolvedValue([mockPartitionGroup])
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartitionGroups: mockFetchPartitionGroups
+        fetchPartitionGroups: mockFetchPartitionGroups,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -69,7 +72,7 @@ describe('PartitionGroup Store', () => {
         .mockRejectedValue(new Error('Network error'))
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartitionGroups: mockFetchPartitionGroups
+        fetchPartitionGroups: mockFetchPartitionGroups,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -89,7 +92,7 @@ describe('PartitionGroup Store', () => {
         .mockResolvedValue(mockPartitionGroup)
       const mockRepo = {
         ...createMockRepository(),
-        fetchPartitionGroup: mockFetchPartitionGroup
+        fetchPartitionGroup: mockFetchPartitionGroup,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -101,7 +104,7 @@ describe('PartitionGroup Store', () => {
       expect(store.editedValue.value).toEqual({
         name: mockPartitionGroup.name,
         parentPartitionGroupId: mockPartitionGroup.parentPartitionGroupId,
-        depth: mockPartitionGroup.depth
+        depth: mockPartitionGroup.depth,
       })
     })
 
@@ -111,7 +114,7 @@ describe('PartitionGroup Store', () => {
         .mockResolvedValue(mockPartitionGroup)
       const mockRepo = {
         ...createMockRepository(),
-        createPartitionGroup: mockCreatePartitionGroup
+        createPartitionGroup: mockCreatePartitionGroup,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -125,12 +128,12 @@ describe('PartitionGroup Store', () => {
     it('editPartitionGroup updates group and list', async () => {
       const mockUpdatedGroup: PartitionGroup = {
         ...mockPartitionGroup,
-        name: 'Updated Group'
+        name: 'Updated Group',
       }
       const mockEditPartitionGroup = vi.fn().mockResolvedValue(mockUpdatedGroup)
       const mockRepo = {
         ...createMockRepository(),
-        editPartitionGroup: mockEditPartitionGroup
+        editPartitionGroup: mockEditPartitionGroup,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -149,7 +152,7 @@ describe('PartitionGroup Store', () => {
       const mockDeletePartitionGroup = vi.fn().mockResolvedValue(undefined)
       const mockRepo = {
         ...createMockRepository(),
-        deletePartitionGroup: mockDeletePartitionGroup
+        deletePartitionGroup: mockDeletePartitionGroup,
       }
       app.provide(PartitionGroupRepositoryKey, mockRepo)
 
@@ -170,7 +173,7 @@ describe('PartitionGroup Store', () => {
       store.partitionGroups.value = [mockPartitionGroup]
 
       expect(store.partitionGroupOptions.value).toEqual([
-        { key: mockPartitionGroup.name, value: mockPartitionGroup.id }
+        { key: mockPartitionGroup.name, value: mockPartitionGroup.id },
       ])
     })
 

--- a/tests/features/tag/store.spec.ts
+++ b/tests/features/tag/store.spec.ts
@@ -1,9 +1,12 @@
+import { createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { TagRepositoryKey } from '@/di'
 import type { Tag } from '@/features/tag/entities'
 import { useTagStore } from '@/features/tag/store'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
 
 describe('Tag Store', () => {
   let app: ReturnType<typeof createApp>
@@ -18,13 +21,13 @@ describe('Tag Store', () => {
 
   const mockTag: Tag = {
     id: 'tag-1',
-    name: 'Tag 1'
+    name: 'Tag 1',
   }
 
   const createMockRepository = () => ({
     fetchTags: vi.fn(),
     createTag: vi.fn(),
-    deleteTag: vi.fn()
+    deleteTag: vi.fn(),
   })
 
   describe('actions', () => {
@@ -32,7 +35,7 @@ describe('Tag Store', () => {
       const mockFetchTags = vi.fn().mockResolvedValue([mockTag])
       const mockRepo = {
         ...createMockRepository(),
-        fetchTags: mockFetchTags
+        fetchTags: mockFetchTags,
       }
       app.provide(TagRepositoryKey, mockRepo)
 
@@ -51,7 +54,7 @@ describe('Tag Store', () => {
         .mockRejectedValue(new Error('Network error'))
       const mockRepo = {
         ...createMockRepository(),
-        fetchTags: mockFetchTags
+        fetchTags: mockFetchTags,
       }
       app.provide(TagRepositoryKey, mockRepo)
 
@@ -70,7 +73,7 @@ describe('Tag Store', () => {
       const mockCreateTag = vi.fn().mockResolvedValue(newTag)
       const mockRepo = {
         ...createMockRepository(),
-        createTag: mockCreateTag
+        createTag: mockCreateTag,
       }
       app.provide(TagRepositoryKey, mockRepo)
 
@@ -79,7 +82,7 @@ describe('Tag Store', () => {
 
       const result = await store.ensureTags([
         existingTag,
-        { id: '', name: 'New' } as Tag
+        { id: '', name: 'New' } as Tag,
       ])
 
       expect(mockCreateTag).toHaveBeenCalledWith('New')
@@ -91,7 +94,7 @@ describe('Tag Store', () => {
       const mockDeleteTag = vi.fn().mockResolvedValue(undefined)
       const mockRepo = {
         ...createMockRepository(),
-        deleteTag: mockDeleteTag
+        deleteTag: mockDeleteTag,
       }
       app.provide(TagRepositoryKey, mockRepo)
 
@@ -112,7 +115,7 @@ describe('Tag Store', () => {
       store.tags.value = [mockTag]
 
       expect(store.tagOptions.value).toEqual([
-        { key: mockTag.name, value: mockTag }
+        { key: mockTag.name, value: mockTag },
       ])
     })
 
@@ -122,7 +125,7 @@ describe('Tag Store', () => {
       store.tags.value = [mockTag]
 
       expect(store.tagIdOptions.value).toEqual([
-        { key: mockTag.name, value: mockTag.id }
+        { key: mockTag.name, value: mockTag.id },
       ])
     })
   })

--- a/tests/features/user/store.spec.ts
+++ b/tests/features/user/store.spec.ts
@@ -1,9 +1,12 @@
+import { createApp } from 'vue'
+
+import { createPinia, setActivePinia } from 'pinia'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { UserRepositoryKey } from '@/di'
 import type { User } from '@/features/user/entities'
 import { useUserStore } from '@/features/user/store'
-import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp } from 'vue'
 
 describe('User Store', () => {
   let app: ReturnType<typeof createApp>
@@ -20,14 +23,14 @@ describe('User Store', () => {
     id: 'user-1',
     name: 'test-user',
     displayName: 'Test User',
-    accountManager: false
+    accountManager: false,
   }
 
   const mockAdminUser: User = {
     id: 'admin-1',
     name: 'admin-user',
     displayName: 'Admin User',
-    accountManager: true
+    accountManager: true,
   }
 
   describe('actions', () => {
@@ -37,7 +40,7 @@ describe('User Store', () => {
         .mockResolvedValue([mockUser, mockAdminUser])
       app.provide(UserRepositoryKey, {
         fetchUsers: mockFetchUsers,
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
 
       const store = app.runWithContext(() => useUserStore())
@@ -55,7 +58,7 @@ describe('User Store', () => {
         .mockRejectedValue(new Error('Network error'))
       app.provide(UserRepositoryKey, {
         fetchUsers: mockFetchUsers,
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
 
       const store = app.runWithContext(() => useUserStore())
@@ -70,7 +73,7 @@ describe('User Store', () => {
       const mockFetchMe = vi.fn().mockResolvedValue(mockUser)
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: mockFetchMe
+        fetchMe: mockFetchMe,
       })
 
       const store = app.runWithContext(() => useUserStore())
@@ -85,7 +88,7 @@ describe('User Store', () => {
       const mockFetchMe = vi.fn().mockResolvedValue(mockUser)
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: mockFetchMe
+        fetchMe: mockFetchMe,
       })
 
       const store = app.runWithContext(() => useUserStore())
@@ -99,7 +102,7 @@ describe('User Store', () => {
       const mockFetchMe = vi.fn().mockRejectedValue(new Error('Network error'))
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: mockFetchMe
+        fetchMe: mockFetchMe,
       })
 
       const store = app.runWithContext(() => useUserStore())
@@ -111,7 +114,7 @@ describe('User Store', () => {
     it('reset clears state', () => {
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
       const store = app.runWithContext(() => useUserStore())
       store.me.value = mockUser
@@ -133,7 +136,7 @@ describe('User Store', () => {
     it('isAccountManager returns correct value', () => {
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
       const store = app.runWithContext(() => useUserStore())
 
@@ -150,28 +153,28 @@ describe('User Store', () => {
     it('userOptions returns formatted options', () => {
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
       const store = app.runWithContext(() => useUserStore())
       store.users.value = [mockUser, mockAdminUser]
 
       expect(store.userOptions.value).toEqual([
         { key: mockUser.name, value: mockUser.id },
-        { key: mockAdminUser.name, value: mockAdminUser.id }
+        { key: mockAdminUser.name, value: mockAdminUser.id },
       ])
     })
 
     it('userMap returns id-name map', () => {
       app.provide(UserRepositoryKey, {
         fetchUsers: vi.fn(),
-        fetchMe: vi.fn()
+        fetchMe: vi.fn(),
       })
       const store = app.runWithContext(() => useUserStore())
       store.users.value = [mockUser, mockAdminUser]
 
       expect(store.userMap.value).toEqual({
         [mockUser.id]: mockUser.name,
-        [mockAdminUser.id]: mockAdminUser.name
+        [mockAdminUser.id]: mockAdminUser.name,
       })
     })
   })

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,11 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }, // vite.config.ts の resolve.alias と対応
     "types": ["vite/client"],
-    "noImplicitOverride": true,
-    "noFallthroughCasesInSwitch": true
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedSideEffectImports": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,8 @@ export default defineConfig(({ mode }) => {
     plugins: [vue(), brotli(), tailwindcss()],
     resolve: {
       alias: {
-        '@': path.resolve(__dirname, 'src')
-      }
+        '@': path.resolve(__dirname, 'src'),
+      },
     },
     server: {
       port: 3000,
@@ -22,12 +22,12 @@ export default defineConfig(({ mode }) => {
         '/api': {
           target: env.VITE_SERVER_HOST,
           changeOrigin: true,
-          agent: keepAliveAgent
-        }
-      }
+          agent: keepAliveAgent,
+        },
+      },
     },
     optimizeDeps: {
-      include: ['axe-core']
-    }
+      include: ['axe-core'],
+    },
   }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,11 +6,11 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src')
-    }
+      '@': path.resolve(__dirname, 'src'),
+    },
   },
   test: {
     include: ['tests/**/*.spec.ts'],
-    environment: 'happy-dom'
-  }
+    environment: 'happy-dom',
+  },
 })


### PR DESCRIPTION
## Summary
Standardizes the linting and formatting configuration to strictly separate concerns: Prettier for style, ESLint/TypeScript for logic.

## Changes

### ESLint
- **Prettier Integration**: Switched to \`@vue/eslint-config-prettier/skip-formatting\` to completely disable formatting rules.
- **Vitest**: Migrated to \`@vitest/eslint-plugin\` for better test file linting and fixed global variable issues.
- **Imports**:
  - Added \`eslint-plugin-unused-imports\` to handle unused imports and variables.
  - Disabled \`import/order\` to delegate import sorting to Prettier.
- **Stylistic Rules**: Removed \`vueTsConfigs.stylisticTypeChecked\` to avoid conflicts with Prettier.

### Prettier
- **Import Sorting**: Configured \`@trivago/prettier-plugin-sort-imports\` with a specific order.
- **Tailwind**: Ensured \`prettier-plugin-tailwindcss\` is loaded last.
- **Ignores**: Added build artifacts and generated files to \`.prettierignore\`.

### TypeScript
- **Strict Checks**: Enabled \`noUnusedLocals\`, \`noUnusedParameters\`, and other strict checks in \`tsconfig.app.json\`.

### Tooling
- **Husky & lint-staged**: Added pre-commit hooks to run format and lint on staged files.
- **CI**: Updated GitHub Actions to use \`npm run lint:ci\` (which enforces max-warnings=0).

## Motivation
To improve developer experience and maintainability by having a clear separation of duties between tools and ensuring consistent code style via automation.