### PR TITLE
chore: `package.json`にpackageManagerを指定

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=24.0.0"
   },
+  "packageManager": "npm@11.6.1",
   "scripts": {
     "dev": "vite",
     "serve": "vite preview",


### PR DESCRIPTION
Dependabotでnpm v8が使われていた問題への対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プロジェクトの推奨パッケージマネージャーとして npm@11.6.1 を指定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->