### PR TITLE
fix:使用可能のパーティションのみを表示するように

### DIFF
--- a/src/components/applicationDetail/ApplicationPartition.vue
+++ b/src/components/applicationDetail/ApplicationPartition.vue
@@ -16,7 +16,7 @@ const application = defineModel<ApplicationDetail>('modelValue', {
 })
 
 const { me } = useUserStore()
-const { partitionOptions } = usePartitionStore()
+const { availablePartitionOptions } = usePartitionStore()
 const { isApplicationCreator } = useApplication(application.value)
 const { editApplication } = useApplicationStore()
 const toast = useToast()
@@ -61,7 +61,7 @@ const handleUpdatePartition = async () => {
         v-else
         v-model="editedPartition"
         label="パーティション"
-        :options="partitionOptions"
+        :options="availablePartitionOptions"
         @close="handleUpdatePartition" />
     </div>
   </div>

--- a/src/features/partition/store.ts
+++ b/src/features/partition/store.ts
@@ -25,6 +25,15 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
     }))
   )
 
+  const availablePartitionOptions = computed(() =>
+    partitions.value
+      .filter(partition => partition.management.state === 'available')
+      .map(partition => ({
+        key: partition.name,
+        value: partition.id,
+      }))
+  )
+
   const canEditPartition = computed(() => (user: User | undefined) => {
     if (!user) return false
     return user.accountManager
@@ -93,6 +102,7 @@ export const usePartitionStore = defineStoreComposable('partition', () => {
     error,
     isPartitionFetched,
     partitionOptions,
+    availablePartitionOptions,
     canEditPartition,
     fetchPartitions,
     fetchPartition,

--- a/src/pages/NewApplicationPage.vue
+++ b/src/pages/NewApplicationPage.vue
@@ -17,7 +17,7 @@ import { useNewApplication } from './composables/useNewApplication'
 
 const { isTagFetched, fetchTags } = useTagStore()
 const { isUserFetched, fetchUsers, me } = useUserStore()
-const { isPartitionFetched, partitionOptions, fetchPartitions } =
+const { isPartitionFetched, availablePartitionOptions, fetchPartitions } =
   usePartitionStore()
 
 const { isSending, application, files, postApplication } = useNewApplication()
@@ -63,7 +63,7 @@ if (!isUserFetched.value) {
     <SearchSelect
       v-model="application.partition"
       class="w-full"
-      :options="partitionOptions"
+      :options="availablePartitionOptions"
       label="パーティション" />
     <SearchSelectTag v-model="application.tags" />
     <NewApplicationFileForm v-model="files" />


### PR DESCRIPTION
申請画面でパーティションを選択するときに、使用不可のパーティションも選択できていた。
なので、使用可能のパーティションのみの一覧を追加。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * アプリケーション設定時のパーティション選択において、利用可能なパーティションのみを表示するように改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->