### PR TITLE
ci: check-mswを削除し、生成ファイル更新PRを自動作成するよう変更

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -109,26 +109,6 @@ jobs:
             echo "Generated APIs are outdated or modified. Please run 'pnpm gen-api' and commit the changes."
             exit 1
           }
-  check-msw:
-    name: Check MSW
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: ./.node-version
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm exec msw init
-      - name: Check for differences in msw worker
-        run: |
-          git diff --exit-code public/mockServiceWorker.js || {
-            echo "public/mockServiceWorker.js is outdated. Please run 'pnpm exec msw init' and commit the changes."
-            exit 1
-          }
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -23,7 +23,7 @@ jobs:
       - run: pnpm exec msw init public/ --save
       - uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "chore: auto-update generated files"
-          title: "chore: auto-update generated files"
-          body: "Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates."
-          branch: "update-generated-files"
+          commit-message: 'chore: auto-update generated files'
+          title: 'chore: auto-update generated files'
+          body: 'Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates.'
+          branch: 'update-generated-files'

--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -1,0 +1,29 @@
+name: Update generated files
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-generated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ./.node-version
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm exec msw init public/ --save
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: auto-update generated files"
+          title: "chore: auto-update generated files"
+          body: "Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates."
+          branch: "update-generated-files"


### PR DESCRIPTION
## 概要
- `common.yml` から `check-msw` ジョブを削除
- `main` ブランチへの `push` 時に `update-generated.yml` を実行し、`pnpm install` と `msw init` で差分が出た場合に自動で更新PRを作成するように変更