### PR TITLE
ci: 生成ファイル更新PRのauto-mergeを有効化

### DIFF
--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -21,7 +21,7 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm exec msw init public/ --save
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         id: cpr
         with:
           commit-message: 'chore: auto-update generated files'

--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -22,8 +22,14 @@ jobs:
       - run: pnpm install
       - run: pnpm exec msw init public/ --save
       - uses: peter-evans/create-pull-request@v6
+        id: cpr
         with:
           commit-message: 'chore: auto-update generated files'
           title: 'chore: auto-update generated files'
           body: 'Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates.'
           branch: 'update-generated-files'
+      - name: Enable Auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
## 概要
- `create-pull-request` で作成された PR に対して自動で `gh pr merge --auto` を実行し、自動マージされるようにしました。