### PR TITLE
fix(ci): update-generatedのDuplicate headerエラーを修正

### DIFF
--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## 概要
update-generatedワークフローで発生していた Duplicate header: Authorization エラーを修正します。

## 動機
actions/checkout がデフォルトで保存する認証情報と、peter-evans/create-pull-request が使用する認証情報が競合し、git操作時にエラーが発生していました。
actions/checkout の persist-credentials を false に設定することで、この重複を回避します。

## 確認手順
- CIが正常に通ることを確認する
- PRマージ後、update-generated の Action が正常に動作するか確認する