### PR TITLE
fix(ci): update-generatedでPAT_TOKENを使用し承認待ちを回避

### DIFF
--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: cpr
         with:
+          token: ${{ secrets.PAT_TOKEN }}
           commit-message: 'chore: auto-update generated files'
           title: 'chore: auto-update generated files'
           body: 'Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates.'


### PR DESCRIPTION
## 概要
update-generatedによって作成されたPRのCIが承認待ち (workflows awaiting approval) になる問題を修正します。

## 動機
デフォルトの GITHUB_TOKEN (github-actions[bot]) で作成されたPRは、セキュリティ上の制約からそのままではワークフローがトリガーされず承認が必要になる場合があります。
create-pull-request アクションにリポジトリで既に設定されている PAT_TOKEN を渡すことで、メンテナー権限でのPR作成となり、自動でワークフローが実行されるようになります。