### PR TITLE
ci: create-pull-requestで自動的にOxojoにレビューリクエストを飛ばす

### DIFF
--- a/.github/workflows/update-generated.yml
+++ b/.github/workflows/update-generated.yml
@@ -29,6 +29,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           commit-message: 'chore: auto-update generated files'
           title: 'chore: auto-update generated files'
+          reviewers: Oxojo
           body: 'Automated PR to update generated files (e.g. MSW worker and lockfile) after dependency updates.'
           branch: 'update-generated-files'
       - name: Enable Auto-merge


### PR DESCRIPTION
## 概要
update-generated の自動生成PRで、自動的に @Oxojo にレビューリクエストを飛ばすように設定します。

## 動機
CODEOWNERS の対象となっていない自動生成ファイル（public/mockServiceWorker.js など）が更新された際にも、確実にメンテナーへレビュー依頼が届くようにするためです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローの自動生成ファイル更新プロセスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->