### PR TITLE
払い戻し対象者が1人の時に削除できなくする

### DIFF
--- a/src/components/applicationDetail/ApplicationTargetEditor.vue
+++ b/src/components/applicationDetail/ApplicationTargetEditor.vue
@@ -11,6 +11,7 @@ import { useUserStore } from '@/features/user/store'
 
 const props = defineProps<{
   application: ApplicationDetail
+  canDelete: boolean
   selectedUserIds: string[]
 }>()
 
@@ -42,13 +43,17 @@ const targetAmountDraft = computed<number | null>({
 })
 
 const handleRemoveTarget = () => {
-  // TODO: confirmをカスタムモーダルに置き換える
-  const result = confirm('本当に削除しますか？')
-  if (!result) {
+  // 払い戻し対象者が一人の時にボタンを押せなくする
+  if (props.canDelete) {
+    // TODO: confirmをカスタムモーダルに置き換える
+    const result = confirm('本当に削除しますか？')
+    if (!result) {
+      return
+    }
+    emit('delete', targetModel.value.id)
     return
   }
 
-  emit('delete', targetModel.value.id)
   return
 }
 </script>
@@ -65,7 +70,11 @@ const handleRemoveTarget = () => {
           ¥
         </span>
       </BaseNumberInput>
-      <button @click="handleRemoveTarget">
+      <button
+        :disabled="!canDelete"
+        class="mt-auto mb-2 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md text-error-primary disabled:cursor-not-allowed disabled:opacity-30"
+        type="button"
+        @click="handleRemoveTarget">
         <TrashIcon class="w-6 cursor-pointer text-error-primary" />
       </button>
     </div>

--- a/src/components/applicationDetail/ApplicationTargets.vue
+++ b/src/components/applicationDetail/ApplicationTargets.vue
@@ -25,6 +25,7 @@ const hasAuthority = isApplicationCreator.value(me.value)
 
 const isEditMode = ref(false)
 const editedTargets = ref(props.application.targets.map(t => ({ ...t })))
+const canDeleteTargets = computed(() => editedTargets.value.length > 1)
 
 const selectedUserIds = computed(() =>
   isEditMode.value
@@ -33,6 +34,10 @@ const selectedUserIds = computed(() =>
 )
 
 const handleDeleteTarget = (id: string) => {
+  if (!canDeleteTargets.value) {
+    toast.error('払い戻し対象者は1人未満にできません')
+    return
+  }
   editedTargets.value = editedTargets.value.filter(target => target.id !== id)
 }
 
@@ -85,6 +90,7 @@ const handleUpdateTargets = async () => {
             v-if="editedTargets[i]"
             v-model:target-model="editedTargets[i]"
             :application="application"
+            :can-delete="canDeleteTargets"
             :selected-user-ids="selectedUserIds"
             @delete="handleDeleteTarget" />
           <div v-else class="text-error-primary">


### PR DESCRIPTION
# やったこと
払い戻し対象者が1人の時に、削除ボタンが半透明になり、削除できないようにした
close #820 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 編集画面で、削除できない対象者の削除ボタンを無効化するようになりました。
* **バグ修正**
  * 対象者が 1 人以下になる場合は削除を実行せず、エラーメッセージを表示するようになりました。
  * 削除不可の状態では確認ダイアログが表示されず、誤って削除操作を進められないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->