### PR TITLE
fix: 他人の申請に写真を追加できないようにした

### DIFF
--- a/src/components/applicationDetail/ApplicationAttachment.vue
+++ b/src/components/applicationDetail/ApplicationAttachment.vue
@@ -48,7 +48,7 @@ const handleFileUpload = () => {
       </div>
     </div>
   </div>
-  <div v-if="userId === applicantId" class="flex justify-end">
+  <div v-if="userId && userId === applicantId" class="flex justify-end">
     <label
       class="flex cursor-pointer items-center rounded-md border border-surface-secondary px-4 py-2 hover:bg-hover-primary"
       for="file_upload">

--- a/src/components/applicationDetail/ApplicationAttachment.vue
+++ b/src/components/applicationDetail/ApplicationAttachment.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { useToast } from 'vue-toastification'
 
-defineProps<{ files: string[] }>()
+defineProps<{
+  files: string[]
+  userId: string
+  applicantId: string
+}>()
 const toast = useToast()
 
 const handleFileUpload = () => {
@@ -44,7 +48,7 @@ const handleFileUpload = () => {
       </div>
     </div>
   </div>
-  <div class="flex justify-end">
+  <div v-if="userId === applicantId" class="flex justify-end">
     <label
       class="flex cursor-pointer items-center rounded-md border border-surface-secondary px-4 py-2 hover:bg-hover-primary"
       for="file_upload">

--- a/src/components/applicationDetail/ApplicationContent.vue
+++ b/src/components/applicationDetail/ApplicationContent.vue
@@ -76,7 +76,10 @@ const handleUpdateContent = async () => {
         v-if="!isEditMode"
         class="w-full flex-1 rounded-lg border border-surface-secondary px-4 py-3">
         <MarkdownIt :text="application.content" />
-        <ApplicationAttachment :files="application.files" />
+        <ApplicationAttachment
+          :files="application.files"
+          :user-id="me?.id ?? ''"
+          :applicant-id="application.createdBy" />
       </div>
       <MarkdownTextarea
         v-else


### PR DESCRIPTION
#792 

申請者IDとログイン者IDを取得し、一致した場合のみ画像を追加できるようにしました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 添付ファイルの追加操作を申請者本人に限定しました。
  * 申請者本人の場合のみ、添付ファイル追加用の入力欄が表示されます。

* **改善**
  * 申請者以外には添付ファイル追加欄を表示しないよう、画面表示を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->